### PR TITLE
Fix MongoDB Error when using `,,cfg r +`/`-`

### DIFF
--- a/lyra/src/modules/config.py
+++ b/lyra/src/modules/config.py
@@ -127,7 +127,8 @@ async def restrict_list_edit(
 ):
     assert ctx.guild_id
     flt = {'id': str(ctx.guild_id)}
-    g_cfg = cfg.find_one()
+
+    g_cfg = cfg.find_one(flt)
     assert g_cfg
 
     res_ch = g_cfg.setdefault('restricted_ch', {})


### PR DESCRIPTION
Fixes #6