### PR TITLE
Relaxed Unneeded Pauses When Everyone Left VC + Logging Support When Bot is Forcefully Moved

### DIFF
--- a/lyra/src/client.py
+++ b/lyra/src/client.py
@@ -80,7 +80,7 @@ async def prefix_getter(
     return prefixes
 
 
-@_client.with_listener(hk.StartedEvent)
+@_client.with_listener()
 async def on_started(
     _: hk.StartedEvent,
     client: al.Injected[tj.Client],
@@ -103,7 +103,7 @@ async def on_started(
     repeat_emojis.extend(emoji_refs[f'repeat{n}_b'] for n in range(3))
 
 
-@_client.with_listener(hk.ShardReadyEvent)
+@_client.with_listener()
 async def on_shard_ready(
     event: hk.ShardReadyEvent,
     client: al.Injected[tj.Client],
@@ -129,7 +129,7 @@ async def on_shard_ready(
     client.set_type_dependency(lv.Lavalink, lvc)
 
 
-@_client.with_listener(hk.VoiceStateUpdateEvent)
+@_client.with_listener()
 async def on_voice_state_update(
     event: hk.VoiceStateUpdateEvent,
     lvc: al.Injected[lv.Lavalink],
@@ -147,7 +147,7 @@ async def on_voice_state_update(
     )
 
 
-@_client.with_listener(hk.VoiceServerUpdateEvent)
+@_client.with_listener()
 async def on_voice_server_update(
     event: hk.VoiceServerUpdateEvent,
     lvc: al.Injected[lv.Lavalink],

--- a/lyra/src/lib/_extras_types.py
+++ b/lyra/src/lib/_extras_types.py
@@ -26,7 +26,6 @@ Panic = Result
 Require = t.Annotated[_T_co, ...]
 MaybeIterable = _T | t.Iterable[_T]
 
-VoidCoro = t.Awaitable[None]
 OptionResult = Option[Result[_T]]
 
 _DecoratedT = t.TypeVar('_DecoratedT')

--- a/lyra/src/lib/compose.py
+++ b/lyra/src/lib/compose.py
@@ -64,7 +64,6 @@ def with_cb_check(
     vote: bool = False,
     prompt: bool = False,
 ):
-    from .extras import VoidCoro
     from .musicutils import start_listeners_voting
 
     P = t.ParamSpec('P')
@@ -144,7 +143,9 @@ def with_cb_check(
         if (await get_queue(ctx_, lvc)).is_paused:
             raise TrackPaused
 
-    def callback(func: t.Callable[P, VoidCoro]) -> t.Callable[P, VoidCoro]:
+    def callback(
+        func: t.Callable[P, t.Awaitable[None]]
+    ) -> t.Callable[P, t.Awaitable[None]]:
         @ft.wraps(func)
         async def inner(*args: P.args, **kwargs: P.kwargs) -> None:
 

--- a/lyra/src/lib/connections.py
+++ b/lyra/src/lib/connections.py
@@ -140,8 +140,10 @@ async def join(
         await ctx.rest.edit_my_voice_state(ctx.guild_id, new_ch, request_to_speak=True)
 
     if old_conn and old_ch:
+        async with access_data(ctx, lvc) as d:
+            d.vc_change_intended = True
         logger.info(
-            f"In guild {ctx.guild_id} moved   from    {old_ch} > {ch_type: <7} {new_ch}"
+            f"In guild {ctx.guild_id} moved   from    {old_ch} > {ch_type: <7} {new_ch} gracefully"
         )
         raise ChannelMoved(old_ch, new_ch, to_stage=is_stage)
 
@@ -166,7 +168,7 @@ async def leave(ctx: tj.abc.Context, lvc: lv.Lavalink, /) -> Result[hk.Snowflake
     await others_not_in_vc_check_impl(ctx, conn)
 
     async with access_data(ctx, lvc) as d:
-        d.dc_on_purpose = True
+        d.vc_change_intended = True
 
     await cleanup(ctx.guild_id, ctx.client.shards, lvc)
 

--- a/lyra/src/lib/expects.py
+++ b/lyra/src/lib/expects.py
@@ -6,7 +6,7 @@ import attr as a
 import lavasnek_rs as lv
 
 from .utils import Contextish, dj_perms_fmt, err_say, get_pref, get_rest, say
-from .extras import Result, VoidCoro, format_flags
+from .extras import Result, format_flags
 from .errors import (
     CommandCancelled,
     ErrorNotRecognized,
@@ -34,7 +34,9 @@ class BaseErrorExpects(abc.ABC):
     context: Contextish
 
     @abc.abstractmethod
-    def match_expect(self, error: Exception, /) -> Result[t.Callable[[], VoidCoro]]:
+    def match_expect(
+        self, error: Exception, /
+    ) -> Result[t.Callable[[], t.Awaitable[None]]]:
         ...
 
     @abc.abstractmethod
@@ -135,7 +137,9 @@ class CheckErrorExpects(BaseErrorExpects):
     async def expect_not_developer(self):
         await err_say(self.context, content="🚫⚙️ Reserved for bot's developers only")
 
-    def match_expect(self, error: Exception, /) -> Result[t.Callable[[], VoidCoro]]:
+    def match_expect(
+        self, error: Exception, /
+    ) -> Result[t.Callable[[], t.Awaitable[None]]]:
         match error:
             case lv.NetworkError():
                 return lambda: self.expect_network_error()
@@ -196,7 +200,9 @@ class BindErrorExpects(BaseErrorExpects):
             content=f"❌ Please join a voice channel first. You can also do `{p}join channel:` `[🔊 ...]`",
         )
 
-    def match_expect(self, error: Exception, /) -> Result[t.Callable[[], VoidCoro]]:
+    def match_expect(
+        self, error: Exception, /
+    ) -> Result[t.Callable[[], t.Awaitable[None]]]:
         match error:
             case NotInVoice():
                 return lambda: self.expect_not_in_voice()

--- a/lyra/src/lib/lavautils.py
+++ b/lyra/src/lib/lavautils.py
@@ -308,7 +308,7 @@ class NodeData:
         default=None, init=False
     )
     track_stopped_fired: bool = a.field(factory=bool, init=False)
-    dc_on_purpose: bool = a.field(factory=bool, init=False)
+    vc_change_intended: bool = a.field(factory=bool, init=False)
     ...
 
     async def edit_now_playing_components(

--- a/lyra/src/lib/playback.py
+++ b/lyra/src/lib/playback.py
@@ -85,7 +85,7 @@ async def set_pause(
     respond: bool = False,
     strict: bool = False,
     update_controller: bool = False,
-) -> Panic[None]:
+) -> Panic[bool]:
     g = infer_guild(g_r_inf)
 
     try:
@@ -98,16 +98,17 @@ async def set_pause(
         if q.is_stopped:
             if strict:
                 raise TrackStopped
-            return
+            return False
         if pause is None:
             pause = not q.is_paused
-        if respond:
-            if pause and q.is_paused:
+        if pause and q.is_paused:
+            if respond:
                 await err_say(g_r_inf, content="❗ Already paused")
-                return
-            if not (pause or q.is_paused):
+            return False
+        if not (pause or q.is_paused):
+            if respond:
                 await err_say(g_r_inf, content="❗ Already resumed")
-                return
+            return False
 
         np_pos = q.np_position
         if np_pos is None:
@@ -160,7 +161,8 @@ async def set_pause(
     except (QueueEmpty, NotPlaying):
         if strict:
             raise
-        pass
+        return False
+    return True
 
 
 async def skip(

--- a/lyra/src/lib/utils.py
+++ b/lyra/src/lib/utils.py
@@ -19,7 +19,6 @@ from .extras import (
     Option,
     Result,
     Panic,
-    VoidCoro,
     URLstr,
     format_flags,
     join_and,
@@ -466,7 +465,7 @@ def with_metadata(**kwargs: t.Any) -> t.Callable[[_CMD], _CMD]:
 _P_mgT = t.ParamSpec('_P_mgT')
 
 
-def with_message_command_group_template(func: t.Callable[_P_mgT, VoidCoro], /):
+def with_message_command_group_template(func: t.Callable[_P_mgT, t.Awaitable[None]], /):
     @ft.wraps(func)
     async def inner(*args: _P_mgT.args, **kwargs: _P_mgT.kwargs):
         ctx = next((a for a in args if isinstance(a, tj.abc.Context)), None)

--- a/lyra/src/modules/connections.py
+++ b/lyra/src/modules/connections.py
@@ -9,7 +9,7 @@ from ..lib.extras import Option, Panic
 from ..lib.connections import logger, cleanup, join_impl_precaught, leave
 from ..lib.musicutils import __init_component__
 from ..lib.utils import JoinableChannelType, dj_perms_fmt, say, err_say
-from ..lib.lavautils import get_data, access_data
+from ..lib.lavautils import get_data, access_data, set_data
 from ..lib.utils import dj_perms_fmt, say, err_say
 from ..lib.extras import Option
 from ..lib.errors import (
@@ -37,14 +37,14 @@ async def to_voice_or_stage_channels(
     return ch
 
 
-@conns.with_listener(hk.VoiceStateUpdateEvent)
+@conns.with_listener()
 async def on_voice_state_update(
     event: hk.VoiceStateUpdateEvent,
     client: al.Injected[tj.Client],
     bot: al.Injected[hk.GatewayBot],
     lvc: al.Injected[lv.Lavalink],
 ):
-    def _conn():
+    def conn():
         return lvc.get_guild_gateway_connection_info(event.guild_id)
 
     new = event.state
@@ -56,13 +56,13 @@ async def on_voice_state_update(
     bot_u = bot.get_me()
     assert bot_u
 
-    def _in_voice() -> frozenset[hk.VoiceState]:
-        conn = _conn()
+    def users_in_vc() -> frozenset[hk.VoiceState]:
+        _conn = conn()
         cache = client.cache
-        if not conn:
+        if not _conn:
             return frozenset()
-        assert isinstance(conn, dict) and cache
-        ch_id: int = conn['channel_id']
+        assert isinstance(_conn, dict) and cache
+        ch_id: int = _conn['channel_id']
         return frozenset(
             filter(
                 lambda v: not v.member.is_bot,
@@ -73,73 +73,56 @@ async def on_voice_state_update(
     new_vc_id = new.channel_id
     out_ch = (d := await get_data(event.guild_id, lvc)).out_channel_id
     assert out_ch
-
-    if not d.dc_on_purpose and old and old.user_id == bot_u.id and not new.channel_id:
-        await cleanup(event.guild_id, client.shards, lvc, also_disconns=False)
-        await client.rest.create_message(
+    if not d.vc_change_intended and old and old.user_id == bot_u.id:
+        d.vc_change_intended = False
+        await set_data(event.guild_id, lvc, d)
+        if not new.channel_id:
+            await cleanup(event.guild_id, client.shards, lvc, also_disconns=False)
+            await bot.rest.create_message(
+                out_ch,
+                f"🥀📎 ~~<#{(_vc := old.channel_id)}>~~ `(Bot was forcefully disconnected)`",
+            )
+            logger.warning(
+                f"In guild {event.guild_id} left    channel {_vc} forcefully"
+            )
+            return
+        is_stage = isinstance(
+            bot.cache.get_guild_channel(new.channel_id), hk.GuildStageChannel
+        )
+        ch_type = 'stage' if is_stage else 'channel'
+        await bot.rest.create_message(
             out_ch,
-            f"🥀📎 ~~<#{(_vc := old.channel_id)}>~~ `(Bot was forcefully disconnected)`",
+            f"🥀📎🖇️ ~~<#{old.channel_id}>~~ ➜ __<#{new_vc_id}>__ `(Bot was forcefully moved)`",
         )
-        logger.warning(f"In guild {event.guild_id} left    channel {_vc} forcefully")
+        logger.warning(
+            f"In guild {event.guild_id} moved   from    {old.channel_id} > {ch_type: <7} {new_vc_id} forcefully"
+        )
         return
 
-    d.dc_on_purpose = False
+    d.vc_change_intended = False
+    await set_data(event.guild_id, lvc, d)
 
-    if not (conn := _conn()):
+    if not (_conn := conn()):
         return
-    assert isinstance(conn, dict)
-
-    from .playback import set_pause
-
-    old_is_stage = (
-        None
-        if not (old and old.channel_id)
-        else isinstance(
-            bot.cache.get_guild_channel(old.channel_id), hk.GuildStageChannel
-        )
-    )
-
-    if (
-        new_vc_id
-        and isinstance(bot.cache.get_guild_channel(new_vc_id), hk.GuildStageChannel)
-        and new.user_id == bot_u.id
-    ):
-        old_suppressed = getattr(old, 'is_suppressed', True)
-        old_requested = getattr(old, 'requested_to_speak_at', None)
-
-        if not old_suppressed and new.is_suppressed and old_is_stage:
-            await set_pause(event, lvc, pause=True, update_controller=True)
-            await client.rest.create_message(
-                out_ch,
-                f"👥▶️ Paused as the bot was moved to audience",
-            )
-        elif old_suppressed and not new.is_suppressed:
-            await client.rest.create_message(
-                out_ch,
-                f"🎭🗣️ Became a speaker",
-            )
-        elif not new.requested_to_speak_at and old_requested:
-            await client.rest.create_message(
-                out_ch, f"❕🎭 Bot's request to speak was dismissed"
-            )
+    assert isinstance(_conn, dict)
 
     async def on_everyone_leaves_vc():
         logger.debug(
-            f"In guild {event.guild_id} started channel {conn['channel_id']} inactivity timeout"
+            f"In guild {event.guild_id} started channel {_conn['channel_id']} inactivity timeout"
         )
         for _ in range(10):
-            if len(_in_voice()) >= 1 or not (_conn()):
+            if len(users_in_vc()) >= 1 or not conn():
                 logger.debug(
-                    f"In guild {event.guild_id} stopped channel {conn['channel_id']} inactivity timeout"
+                    f"In guild {event.guild_id} stopped channel {_conn['channel_id']} inactivity timeout"
                 )
                 return False
             await asyncio.sleep(60)
 
-        __conn = _conn()
+        __conn = conn()
         assert isinstance(__conn, dict)
 
         async with access_data(event.guild_id, lvc) as d:
-            d.dc_on_purpose = True
+            d.vc_change_intended = True
         await cleanup(event.guild_id, client.shards, lvc)
         _vc: int = __conn['channel_id']
         logger.info(
@@ -151,30 +134,20 @@ async def on_voice_state_update(
 
         return True
 
-    in_voice = _in_voice()
-    node_vc_id: int = conn['channel_id']
-    # if new.channel_id == vc and len(in_voice) == 1 and new.user_id != bot_u.id:
-    #     # Someone rejoined
-    #     try:
-    #         await set_pause__(event.guild_id, lvc, pause=False)
-    #         await client.rest.create_message(ch, f"✨⏸️ Resumed")
-    #     except NotConnected:
-    #         pass
+    in_voice = users_in_vc()
+    node_vc_id: int = _conn['channel_id']
 
-    if (new_vc_id != node_vc_id) and not in_voice:
-        if old and old.channel_id == node_vc_id:
-            # Everyone left
-
-            # TODO: Should be in `playback.py`
-            await set_pause(event, lvc, pause=True, update_controller=True)
-            await client.rest.create_message(
-                out_ch, f"🕊️▶️ Paused as no one is listening"
-            )
-
-            await asyncio.wait(
-                (asyncio.create_task(on_everyone_leaves_vc()),),
-                return_when=asyncio.FIRST_COMPLETED,
-            )
+    if (
+        new_vc_id != node_vc_id
+        and not in_voice
+        and old
+        and old.channel_id == node_vc_id
+    ):
+        # Everyone left
+        await asyncio.wait(
+            (asyncio.create_task(on_everyone_leaves_vc()),),
+            return_when=asyncio.FIRST_COMPLETED,
+        )
 
 
 # /join

--- a/lyra/src/modules/controller.py
+++ b/lyra/src/modules/controller.py
@@ -4,6 +4,7 @@ import lavasnek_rs as lv
 
 from ..lib.musicutils import __init_component__
 from ..lib.errors import NotConnected
+from ..lib.extras import void
 from ..lib.flags import (
     ALONE__SPEAK__CAN_SEEK_ANY,
     ALONE__SPEAK__NP_YOURS,
@@ -28,7 +29,7 @@ play_pause_impl = with_cb_check(
     | Checks.CONN
     | Checks.QUEUE
     | ALONE__SPEAK__NP_YOURS
-)(play_pause_abs)
+)(void(play_pause_abs))
 skip_impl = with_cb_check(
     Checks.PLAYING | Checks.CONN | Checks.QUEUE | ALONE__SPEAK__NP_YOURS,
 )(skip_abs)
@@ -42,7 +43,7 @@ shuffle_impl = with_cb_check(Checks.QUEUE | Checks.CONN | IN_VC_ALONE)(shuffle_a
 # ~
 
 
-@control.with_listener(hk.InteractionCreateEvent)
+@control.with_listener()
 async def on_interaction_create(
     event: hk.InteractionCreateEvent, lvc: al.Injected[lv.Lavalink]
 ):

--- a/lyra/src/modules/misc.py
+++ b/lyra/src/modules/misc.py
@@ -53,7 +53,7 @@ async def commands_autocomplete(ctx: tj.abc.AutocompleteContext, value: str, /):
     await ctx.set_choices({v: v for v in matches[:25]})
 
 
-@misc.with_listener(hk.StartedEvent)
+@misc.with_listener()
 async def on_started(_: hk.StartedEvent, client: al.Injected[tj.Client]):
     _all_cmds_iter = tuple(client.iter_commands())
     _all_cmds_sep = groupby(_all_cmds_iter, key=lambda cmd: get_cmd_handle(cmd))

--- a/lyra/src/modules/tuning.py
+++ b/lyra/src/modules/tuning.py
@@ -80,7 +80,7 @@ with_stage_cmd_check = with_cmd_composer(
 )
 
 
-@tuning.with_listener(hk.VoiceStateUpdateEvent)
+@tuning.with_listener()
 async def on_voice_state_update(
     event: hk.VoiceStateUpdateEvent, lvc: al.Injected[lv.Lavalink]
 ):


### PR DESCRIPTION
`-` `VoidCoro` Type Alias
`-` Removed events in `.with_listener(...)` as it can be inferred
`+` Support for logging when bot is forcefully moved
 | `*` `NodeData.dc_on_purpose` -> `.vc_change_intended`
`~` Moved automatic playback handling to `playback` module
`#` Suppressed unneeded pauses when everyone left voice
`*` `set_pause(...)` now returns `Panic[bool]` instead
 | `+` `void(...)`
`?` Improved general code styles & conventions