### PR TITLE
Full Command Name Output Support

### DIFF
--- a/lyra/src/lib/_extras_types.py
+++ b/lyra/src/lib/_extras_types.py
@@ -25,6 +25,7 @@ Result = t.Annotated[_T | t.NoReturn, ...]
 Panic = Result
 Require = t.Annotated[_T_co, ...]
 MaybeIterable = _T | t.Iterable[_T]
+AsyncVoidFunction = t.Callable[..., t.Awaitable[None]]
 
 OptionResult = Option[Result[_T]]
 

--- a/lyra/src/lib/extras.py
+++ b/lyra/src/lib/extras.py
@@ -18,6 +18,7 @@ from ._extras_types import (
     NULL,
     RGBTriplet,
     MaybeIterable,
+    AsyncVoidFunction,
     URLstr,
 )
 from ._extras_vars import time_regex, time_regex_2, url_regex, loop

--- a/lyra/src/lib/lavautils.py
+++ b/lyra/src/lib/lavautils.py
@@ -224,7 +224,7 @@ class Bands(tuple[float]):
     @property
     def key(self) -> Option[str]:
         if self.key_ is None:
-            return getattr(self.name, 'lower', lambda: None)()
+            return self.name.lower() if self.name else None
         return self.key_
 
     @classmethod


### PR DESCRIPTION
`+` `AsyncVoidFunction` Type Alias
`+` `ParentCommandType` Type Alias
`?` More safaly type hinted `start_confirmation_prompt(...)` and `on_parser_error`
`*` Support for full command name
 | `*` `with_message_command_group_template(...)`, slightly improved error message
 | `*` `start_confirmation_prompt(...)`