### PR TITLE
Use member's guild avatar when applicable

### DIFF
--- a/lyra/src/lib/lavautils.py
+++ b/lyra/src/lib/lavautils.py
@@ -433,7 +433,7 @@ async def generate_nowplaying_embed(
         .set_author(name="Currently playing")
         .set_footer(
             f"Requested by: {req.display_name}",
-            icon=req.avatar_url or req.default_avatar_url,
+            icon=req.display_avatar_url,
         )
         .set_thumbnail(thumb)
     )

--- a/lyra/src/modules/info.py
+++ b/lyra/src/modules/info.py
@@ -101,7 +101,7 @@ async def nowplaying_(
         .set_author(name="Now playing")
         .set_footer(
             f"Requested by: {req.display_name}",
-            icon=req.avatar_url or ctx.author.default_avatar_url,
+            icon=req.display_avatar_url,
         )
         .set_thumbnail(thumb)
     )


### PR DESCRIPTION
`*` in `generate_nowplaying_embed(...)`
`*` in `/now-playing`