### PR TITLE
Redesigned `/queue` and `/now-playing`'s output

### DIFF
--- a/lyra/src/lib/extras.py
+++ b/lyra/src/lib/extras.py
@@ -134,9 +134,9 @@ def wr(
     replace_with: str = '…',
     /,
     *,
-    block_friendly: bool = True,
+    escape_markdown: bool = True,
 ) -> str:
-    str_ = str_.replace("'", '′').replace('"', '″') if block_friendly else str_
+    str_ = str_.replace('\'', '′').replace('"', '″') if escape_markdown else str_
     return (
         str_ if len(str_) <= limit else str_[: limit - len(replace_with)] + replace_with
     )

--- a/lyra/src/lib/lavautils.py
+++ b/lyra/src/lib/lavautils.py
@@ -424,15 +424,15 @@ async def generate_nowplaying_embed(
         thumb = limit_img_size_by_guild(thumb, guild_id, cache)
     embed = (
         hk.Embed(
-            title=f"🎧 {t_info.title}",
-            description=f'📀 **{t_info.author}** ({song_len})',
+            title=f"🎧 __**`#{q.pos + 1}`**__  {t_info.title}",
+            description=f'👤 **{t_info.author}** ({song_len})',
             url=t_info.uri,
             color=q.curr_t_palette[0],
             timestamp=dt.datetime.now().astimezone(),
         )
         .set_author(name="Currently playing")
         .set_footer(
-            f"Requested by: {req.display_name}",
+            f"📨 {req.display_name}",
             icon=req.display_avatar_url,
         )
         .set_thumbnail(thumb)

--- a/lyra/src/lib/musicutils.py
+++ b/lyra/src/lib/musicutils.py
@@ -170,7 +170,7 @@ async def generate_queue_embeds(
         np_info = np.track.info
         req = ctx.cache.get_member(ctx.guild_id, np.requester)
         assert req is not None
-        np_text = f"```arm\n{q.pos+1: >2}. {to_stamp(np_info.length):>6} | {wr(np_info.title, 50)} |\n````Requested by:` {req.mention}"
+        np_text = f"```arm\n{q.pos+1: >2}. {to_stamp(np_info.length):>6} | {wr(np_info.title, 50)} |\n```📨 {req.mention}"
     else:
         np_text = f"```yaml\n{'---':^63}\n```"
 
@@ -194,8 +194,8 @@ async def generate_queue_embeds(
 
     color = None if q.is_paused or not q.current else q.curr_t_palette[2]
 
-    _base_embed = hk.Embed(title="💿 Queue", description=desc, color=color,).set_footer(
-        f"Queue Duration: {to_stamp(queue_elapsed)} / {to_stamp(queue_durr)} ({to_stamp(queue_eta)} Left)"
+    _base_embed = hk.Embed(title="≡♪ Queue", description=desc, color=color,).set_footer(
+        f"⌛ {to_stamp(queue_elapsed)} (-{to_stamp(queue_eta)}) / {to_stamp(queue_durr)}ㅤ•ㅤ{q.pos+1} (-{len(q)-q.pos-1}) / {len(q)}"
     )
 
     _format = f"```{'brainfuck' if q.repeat_mode is RepeatMode.ONE else 'css'}\n%s\n```"

--- a/lyra/src/lib/utils.py
+++ b/lyra/src/lib/utils.py
@@ -297,7 +297,7 @@ async def say(
             else:
                 assert isinstance(g_r_inf, hk.ComponentInteraction)
                 if show_author and (cnt := kwargs.get('content')):
-                    kwargs['content'] = f"{cnt} *by {g_r_inf.user.mention}*"
+                    kwargs['content'] = f"{cnt} *(📨 __{g_r_inf.user.mention}__)*"
                 msg = await g_r_inf.create_initial_response(
                     hk.ResponseType.MESSAGE_CREATE, **kwargs, flags=flags
                 )

--- a/lyra/src/modules/info.py
+++ b/lyra/src/modules/info.py
@@ -80,7 +80,7 @@ async def nowplaying_(
     )
 
     desc = (
-        f'📀 **{t_info.author}**',
+        f'👤 **{t_info.author}**',
         f"{e} `{np_pos:─<{padding}}{song_len:─>12}`".replace('─', ' ', 1)[::-1]
         .replace('─', ' ', 1)[::-1]
         .replace('─', '▬', progress),
@@ -92,7 +92,7 @@ async def nowplaying_(
         thumb = limit_img_size_by_guild(thumb, ctx, ctx.cache)
     embed = (
         hk.Embed(
-            title=f"{'🎶 ' if not q.is_paused else ''}{t_info.title}",
+            title=f"{'🎶 ' if not q.is_paused else ''}__**`#{q.pos + 1}`**__  {t_info.title}",
             description="%s\n\n%s" % desc,
             url=t_info.uri,
             color=color,
@@ -100,7 +100,7 @@ async def nowplaying_(
         )
         .set_author(name="Now playing")
         .set_footer(
-            f"Requested by: {req.display_name}",
+            f"📨 {req.display_name}",
             icon=req.display_avatar_url,
         )
         .set_thumbnail(thumb)


### PR DESCRIPTION
`?` `wr(block_friendly)` -> `escape_markdown`
`+` Now playing messages will now show the track position
`*` Changed some emojis/text formatting
`*` Reformatted `/queue`'s timestamp footer