### PR TITLE
Fix dm commands not working

### DIFF
--- a/lyra/src/client.py
+++ b/lyra/src/client.py
@@ -54,6 +54,7 @@ _client = globs.__init_client__(
     .load_modules(
         *('src.modules.' + p.stem for p in pl.Path('.').glob('./src/modules/*.py'))
     )
+    .set_dms_enabled_for_app_cmds(False)
 )
 
 activity = hk.Activity(name='/play', type=hk.ActivityType.LISTENING)

--- a/lyra/src/lib/utils.py
+++ b/lyra/src/lib/utils.py
@@ -506,7 +506,8 @@ def with_message_command_group_template(func: t.Callable[_P_mgT, t.Awaitable[Non
 async def restricts_c(
     ctx: tj.abc.Context, /, *, cfg: al.Injected[LyraDBCollectionType]
 ) -> bool:
-    assert ctx.guild_id and ctx.member
+    if not (ctx.guild_id and ctx.member):
+        return True
 
     g_cfg = cfg.find_one({'id': str(ctx.guild_id)})
     assert g_cfg

--- a/lyra/src/modules/config.py
+++ b/lyra/src/modules/config.py
@@ -15,8 +15,8 @@ from ..lib.utils import (
     RESTRICTOR,
     MentionableType,
     PartialMentionableType,
-    with_message_command_group_template,
     with_annotated_args,
+    with_message_command_group_template,
     say,
     err_say,
 )

--- a/lyra/src/modules/misc.py
+++ b/lyra/src/modules/misc.py
@@ -19,7 +19,7 @@ from ..lib.utils import (
 from ..lib.extras import groupby
 
 
-misc = __init_component__(__name__)
+misc = __init_component__(__name__, guild_check=False)
 
 
 # ~
@@ -78,7 +78,7 @@ async def on_started(_: hk.StartedEvent, client: al.Injected[tj.Client]):
 # /ping
 
 
-@tj.as_slash_command('ping', "Shows the bot's latency")
+@tj.as_slash_command('ping', "Shows the bot's latency", dm_enabled=True)
 #
 @tj.as_message_command('ping', 'latency', 'pi', 'lat', 'late', 'png')
 async def ping_(ctx: tj.abc.Context):


### PR DESCRIPTION
`*` Disabled guild checks for `misc` cmd group
`!` relaxed restriction checks to allow dm commands
`*` set default settings for slash commands to disable dms