### PR TITLE
Utilised Tanjun's new features to reduce boilerplate

### DIFF
--- a/lyra/requirements.txt
+++ b/lyra/requirements.txt
@@ -1,7 +1,7 @@
 alluka==0.1.1
 attrs
 hikari==2.0.0.dev110
-hikari-tanjun==2.5.4a1
+hikari-tanjun==2.6.2a1
 lyricsgenius==3.0.1
 PyYAML
 requests

--- a/lyra/src/lib/compose.py
+++ b/lyra/src/lib/compose.py
@@ -259,7 +259,7 @@ def with_cmd_composer(
         cmd.metadata['checks'] = checks
         cmd.metadata['binds'] = binds
         cmd.metadata['perms'] = perms
-        return tj.with_all_checks(*_binds, *_checks)(cmd)
+        return tj.with_all_checks(*_binds, *_checks, follow_wrapped=True)(cmd)
 
     return _with_checks_and_binds
 
@@ -282,7 +282,7 @@ def with_cmd_checks(checks: Checks, /) -> Decorator[_CMD]:
 
     def _with_checks(cmd: _CMD, /) -> _CMD:
         cmd.metadata['checks'] = checks
-        return tj.with_all_checks(*_checks)(cmd)
+        return tj.with_all_checks(*_checks, follow_wrapped=True)(cmd)
 
     return _with_checks
 
@@ -290,7 +290,10 @@ def with_cmd_checks(checks: Checks, /) -> Decorator[_CMD]:
 def with_author_permission_check(permissions: hkperms | int, /) -> Decorator[_CMD]:
     def _with_author_permission_check(cmd: _CMD, /) -> _CMD:
         cmd.metadata['perms'] = permissions
-        return cmd.add_check(ft.partial(_as_author_permission_check, perms=permissions))
+        return tj.with_check(
+            ft.partial(_as_author_permission_check, perms=permissions),
+            follow_wrapped=True,
+        )(cmd)
 
     return _with_author_permission_check
 

--- a/lyra/src/modules/config.py
+++ b/lyra/src/modules/config.py
@@ -255,7 +255,6 @@ async def prefix_sg_m(_: tj.abc.MessageContext):
 
 @prefix_sg_s.with_command
 @tj.as_slash_command('list', "Lists all usable prefixes of the bot")
-# -
 @prefix_sg_m.with_command
 @tj.as_message_command('list', 'l', '.')
 async def prefix_list_(
@@ -285,12 +284,11 @@ async def prefix_list_(
 
 
 @with_annotated_args
-@prefix_sg_s.with_command
 @with_admin_cmd_check
-@tj.as_slash_command('add', "Adds a new prefix of the bot for this guild")
 # -
+@prefix_sg_s.with_command
+@tj.as_slash_command('add', "Adds a new prefix of the bot for this guild")
 @prefix_sg_m.with_command
-@with_admin_cmd_check
 @tj.as_message_command('add', '+', 'a', 'new', 'create', 'n')
 async def prefix_add_(
     ctx: tj.abc.Context,
@@ -322,12 +320,11 @@ async def prefix_add_(
 
 
 @with_annotated_args
+@with_admin_cmd_check
+# -
 @prefix_sg_s.with_command
-@with_admin_cmd_check
 @tj.as_slash_command('remove', "Removes an existing prefix of the bot for this guild")
-#
 @prefix_sg_m.with_command
-@with_admin_cmd_check
 @tj.as_message_command('remove', '-', 'rem', 'r', 'rm', 'd', 'del', 'delete')
 async def prefix_remove_(
     ctx: tj.abc.Context,
@@ -378,14 +375,13 @@ async def nowplayingmsg_sg_m(_: tj.abc.MessageContext):
 ### /config nowplayingmsg toggle
 
 
-@nowplayingmsg_sg_s.with_command
 @with_author_permission_check(hkperms.MANAGE_GUILD)
+# -
+@nowplayingmsg_sg_s.with_command
 @tj.as_slash_command(
     'toggle', "Toggles the now playing messages to be automatically sent or not"
 )
-#
 @nowplayingmsg_sg_m.with_command
-@with_author_permission_check(hkperms.MANAGE_GUILD)
 @tj.as_message_command('toggle', 'tggl', 't')
 async def nowplayingmsg_toggle_(
     ctx: tj.abc.Context, cfg: al.Injected[LyraDBCollectionType]
@@ -433,7 +429,6 @@ async def restrict_sg_m(_: tj.abc.MessageContext):
 
 @restrict_sg_s.with_command
 @tj.as_slash_command('list', "Shows the current restricted channels, roles and members")
-# -
 @restrict_sg_m.with_command
 @tj.as_message_command('list', 'ls', 'l', '.', 'all', '/')
 async def restrict_list_(ctx: tj.abc.Context, cfg: al.Injected[LyraDBCollectionType]):
@@ -479,14 +474,13 @@ async def restrict_list_(ctx: tj.abc.Context, cfg: al.Injected[LyraDBCollectionT
 
 
 @with_annotated_args
-@restrict_sg_s.with_command
 @with_author_permission_check(RESTRICTOR)
+# -
+@restrict_sg_s.with_command
 @tj.as_slash_command(
     'add', "Adds new channels, roles or members to the restricted list"
 )
-#
 @restrict_sg_m.with_command
-@with_author_permission_check(RESTRICTOR)
 @tj.as_message_command('add', 'a', '+')
 # TODO: Remove pyright ignores when tanjun relaxed converter func sig
 async def restrict_add_(
@@ -515,14 +509,13 @@ async def restrict_add_(
 
 
 @with_annotated_args
-@restrict_sg_s.with_command
 @with_restricts_cmd_check
+# -
+@restrict_sg_s.with_command
 @tj.as_slash_command(
     'remove', "Removes existing channels, roles or members from the restricted list"
 )
-#
 @restrict_sg_m.with_command
-@with_restricts_cmd_check
 @tj.as_message_command('remove', 'rm', 'del', 'r', 'd', '-')
 # TODO: Remove pyright ignores when tanjun relaxed converter func sig
 async def restrict_remove_(
@@ -551,12 +544,11 @@ async def restrict_remove_(
 
 
 @with_annotated_args
-@restrict_sg_s.with_command
 @with_restricts_cmd_check
-@tj.as_slash_command('blacklist', "Sets a category's restriction mode to blacklisting")
 # -
+@restrict_sg_s.with_command
+@tj.as_slash_command('blacklist', "Sets a category's restriction mode to blacklisting")
 @restrict_sg_m.with_command
-@with_restricts_cmd_check
 @tj.as_message_command('blacklist', 'bl')
 async def restrict_blacklist_(
     ctx: tj.abc.Context,
@@ -576,12 +568,11 @@ async def restrict_blacklist_(
 
 
 @with_annotated_args
-@restrict_sg_s.with_command
 @with_restricts_cmd_check
-@tj.as_slash_command('whitelist', "Sets a category's restriction mode to whitelisting")
 # -
+@restrict_sg_s.with_command
+@tj.as_slash_command('whitelist', "Sets a category's restriction mode to whitelisting")
 @restrict_sg_m.with_command
-@with_restricts_cmd_check
 @tj.as_message_command('whitelist', 'wl')
 async def restrict_whitelist_(
     ctx: tj.abc.Context,
@@ -598,12 +589,11 @@ async def restrict_whitelist_(
 
 
 @with_annotated_args
-@restrict_sg_s.with_command
 @with_restricts_cmd_check
-@tj.as_slash_command('clear', "Clears a category's restriction mode")
 # -
+@restrict_sg_s.with_command
+@tj.as_slash_command('clear', "Clears a category's restriction mode")
 @restrict_sg_m.with_command
-@with_restricts_cmd_check
 @tj.as_message_command('clear', 'clr')
 async def restrict_clear_(
     ctx: tj.abc.Context,
@@ -627,12 +617,11 @@ async def restrict_clear_(
 ### /config restrict wipe
 
 
-@restrict_sg_s.with_command
 @with_dangerous_restricts_cmd_check
-@tj.as_slash_command('wipe', "Wipes the restricted list of EVERY category")
 # -
+@restrict_sg_s.with_command
+@tj.as_slash_command('wipe', "Wipes the restricted list of EVERY category")
 @restrict_sg_m.with_command
-@with_dangerous_restricts_cmd_check
 @tj.as_message_command('wipe', 'reset', 'wp')
 async def restrict_wipe_(ctx: tj.abc.Context, cfg: al.Injected[LyraDBCollectionType]):
     """Wipes the restricted list of EVERY category"""

--- a/lyra/src/modules/connections.py
+++ b/lyra/src/modules/connections.py
@@ -190,7 +190,6 @@ async def join_(
 
 
 @tj.as_slash_command('leave', "Leaves the voice channel and clears the queue")
-#
 @tj.as_message_command(
     'leave', 'l', 'lv', 'dc', 'disconnect', 'discon', 'eddisntheregoaway'
 )

--- a/lyra/src/modules/debug.py
+++ b/lyra/src/modules/debug.py
@@ -86,9 +86,9 @@ async def module_sg_m(_: tj.abc.MessageContext):
 
 
 @with_annotated_args
+# -
 @module_sg_s.with_command
 @tj.as_slash_command('reload', "Reloads a module")
-#
 @module_sg_m.with_command
 @tj.as_message_command('reload', 'rl')
 async def reload_module(
@@ -110,9 +110,9 @@ async def reload_module(
 
 
 @with_annotated_args
+# -
 @module_sg_s.with_command
 @tj.as_slash_command('unload', "Unloads a module")
-#
 @module_sg_m.with_command
 @tj.as_message_command('unload', 'ul')
 async def unload_module(
@@ -135,9 +135,9 @@ async def unload_module(
 
 
 @with_annotated_args
+# -
 @module_sg_s.with_command
 @tj.as_slash_command('load', "Loads a module")
-#
 @module_sg_m.with_command
 @tj.as_message_command('load', 'lo')
 async def load_module(
@@ -183,7 +183,6 @@ async def command_sg_m(_: tj.abc.MessageContext):
 
 @command_sg_s.with_command
 @tj.as_slash_command('delete-all', "Deletes all application commands")
-#
 @command_sg_m.with_command
 @tj.as_message_command('delete-all', 'deleteall', 'delall', 'wipe', 'wp')
 async def delete_all_app_commands(ctx: tj.abc.Context, bot: al.Injected[hk.GatewayBot]):

--- a/lyra/src/modules/info.py
+++ b/lyra/src/modules/info.py
@@ -42,9 +42,8 @@ with_np_cmd_check = with_cmd_checks(Checks.CONN | Checks.QUEUE | Checks.PLAYING)
 
 
 @with_np_cmd_check
+# -
 @tj.as_slash_command('now-playing', "Displays info of the current track")
-#
-@with_np_cmd_check
 @tj.as_message_command(
     'now-playing', 'nowplaying', 'np', 'now', 'curr', 'current', 'crr'
 )
@@ -119,9 +118,8 @@ with_se_cmd_check_and_connect_vc = with_cmd_composer(
 
 @with_annotated_args
 @with_se_cmd_check_and_connect_vc
+# -
 @tj.as_message_command('search', 'se', 'f', 'yt', 'youtube')
-#
-@with_se_cmd_check_and_connect_vc
 @tj.as_slash_command(
     'search',
     "Searches for tracks on youtube from your query and lets you hear a part of it",
@@ -348,9 +346,8 @@ with_q_cmd_check = with_cmd_checks(Checks.QUEUE | Checks.CONN)
 
 
 @with_q_cmd_check
+# -
 @tj.as_slash_command('queue', "Lists out the entire queue")
-#
-@with_q_cmd_check
 @tj.as_message_command('queue', 'q', 'all')
 async def queue_(
     ctx: tj.abc.Context,
@@ -467,8 +464,8 @@ async def queue_(
 
 
 @with_annotated_args
+# -
 @tj.as_slash_command('lyrics', 'Attempts to find the lyrics of the current song')
-#
 @tj.as_message_command('lyrics', 'ly')
 async def lyrics_(
     ctx: EitherContext,

--- a/lyra/src/modules/misc.py
+++ b/lyra/src/modules/misc.py
@@ -79,7 +79,6 @@ async def on_started(_: hk.StartedEvent, client: al.Injected[tj.Client]):
 
 
 @tj.as_slash_command('ping', "Shows the bot's latency", dm_enabled=True)
-#
 @tj.as_message_command('ping', 'latency', 'pi', 'lat', 'late', 'png')
 async def ping_(ctx: tj.abc.Context):
     """

--- a/lyra/src/modules/playback.py
+++ b/lyra/src/modules/playback.py
@@ -71,11 +71,10 @@ with_activity_cmd_check = with_cmd_checks(COMMON_CHECKS | Checks.PAUSE)
 
 
 @with_common_cmd_check
+# -
 @tj.as_slash_command(
     'play-pause', "Toggles the playback of the current song between play and pause"
 )
-#
-@with_common_cmd_check
 @tj.as_message_command('play-pause', 'playpause', 'pp', '>||')
 async def play_pause_(
     ctx: tj.abc.MessageContext,
@@ -189,9 +188,8 @@ async def on_voice_state_update(
 
 
 @with_common_cmd_check
+# -
 @tj.as_slash_command('pause', "Pauses the current song")
-#
-@with_common_cmd_check
 @tj.as_message_command('pause', '>', 'ps')
 async def pause_(
     ctx: tj.abc.Context,
@@ -207,9 +205,8 @@ async def pause_(
 
 
 @with_common_cmd_check
+# -
 @tj.as_slash_command("resume", "Resumes the current track")
-#
-@with_common_cmd_check
 @tj.as_message_command('resume', 'res', 'rs', '||')
 async def resume_(
     ctx: tj.abc.Context,
@@ -225,9 +222,8 @@ async def resume_(
 
 
 @with_common_cmd_check
+# -
 @tj.as_slash_command('stop', "Stops the current track; skip to play again")
-#
-@with_common_cmd_check
 @tj.as_message_command('stop', 'st', '[]')
 async def stop_(
     ctx: tj.abc.MessageContext,
@@ -243,12 +239,11 @@ async def stop_(
 
 # TODO: Use annotation-based option declaration once declaring positional-only argument is possible
 @with_activity_cmd_check
+# -
 @tj.with_float_slash_option(
     'seconds', "Fast-foward by how much? (If not given, 10 seconds)", default=10.0
 )
 @tj.as_slash_command('fast-forward', "Fast-forwards the current track")
-#
-@with_activity_cmd_check
 @tj.with_argument('seconds', converters=float, default=10.0)
 @tj.as_message_command(
     'fast-forward', 'fastforward', 'forward', 'fw', 'fwd', 'ff', '>>'
@@ -284,12 +279,11 @@ async def fastforward_(
 
 # TODO: Use annotation-based option declaration once declaring positional-only argument is possible
 @with_activity_cmd_check
+# -
 @tj.with_float_slash_option(
     'seconds', "Rewind by how much? (If not given, 10 seconds)", default=10.0
 )
 @tj.as_slash_command('rewind', "Rewinds the current track")
-#
-@with_activity_cmd_check
 @tj.with_argument('seconds', converters=float, default=10.00)
 @tj.as_message_command('rewind', 'rw', 'rew', '<<')
 async def rewind_(
@@ -326,9 +320,8 @@ with_skip_cmd_check_and_voting = with_cmd_composer(
 
 
 @with_skip_cmd_check_and_voting
+# -
 @tj.as_slash_command('skip', "Skips the current track")
-#
-@with_skip_cmd_check_and_voting
 @tj.as_message_command('skip', 's', '>>|')
 async def skip_(
     ctx: tj.abc.Context,
@@ -348,9 +341,8 @@ with_playat_cmd_check_and_voting = with_cmd_composer(
 
 @with_annotated_args
 @with_playat_cmd_check_and_voting
+# -
 @tj.as_slash_command("play-at", "Plays the track at the specified position")
-#
-@with_playat_cmd_check_and_voting
 @tj.as_message_command('play-at', 'playat', 'pa', 'i', 'pos', 'skipto', '->', '^')
 async def play_at_(
     ctx: tj.abc.Context,
@@ -391,9 +383,8 @@ with_next_cmd_check = with_cmd_checks(
 
 
 @with_next_cmd_check
+# -
 @tj.as_slash_command('next', "Plays the next track in the queue")
-#
-@with_next_cmd_check
 @tj.as_message_command('next', 'n')
 async def next_(
     ctx: tj.abc.Context,
@@ -415,9 +406,8 @@ with_prev_cmd_check_and_voting = with_cmd_composer(
 
 
 @with_prev_cmd_check_and_voting
+# -
 @tj.as_slash_command('previous', "Plays the previous track in the queue")
-#
-@with_prev_cmd_check_and_voting
 @tj.as_message_command('previous', 'prev', 'pr', 'prv', 'pre', 'b', 'back', '|<<')
 async def previous_(
     ctx: tj.abc.Context,
@@ -456,9 +446,8 @@ async def restart_(ctx: tj.abc.Context, lvc: al.Injected[lv.Lavalink]):
 
 @with_annotated_args
 @with_activity_cmd_check
+# -
 @tj.as_slash_command("seek", "Seeks the current track to a timestamp")
-#
-@with_activity_cmd_check
 @tj.as_message_command('seek', 'sk', '-v', '-^')
 async def seek_(
     ctx: tj.abc.Context,

--- a/lyra/src/modules/queue.py
+++ b/lyra/src/modules/queue.py
@@ -233,8 +233,9 @@ async def remove_g_m(_: tj.abc.MessageContext):
 
 
 # TODO: Use annotation-based option declaration once declaring positional-only argument is possible
-@remove_g_s.with_command
 @with_stage_cmd_check
+# -
+@remove_g_s.with_command
 @tj.with_str_slash_option(
     'track',
     "The track by the name/position what? (If not given, the current track)",
@@ -243,7 +244,7 @@ async def remove_g_m(_: tj.abc.MessageContext):
 @tj.as_slash_command(
     'one', "Removes a track from the queue by queue position or track name"
 )
-# -
+#
 @remove_g_m.with_command
 @with_stage_cmd_check
 @tj.with_greedy_argument('track', default=None)
@@ -278,8 +279,9 @@ async def remove_one_(
 
 
 # TODO: Use annotation-based option declaration once declaring positional-only argument is possible
-@remove_g_s.with_command
 @with_strict_stage_cmd_check
+# -
+@remove_g_s.with_command
 @tj.with_int_slash_option(
     'end',
     "To what position? (If not given, the end of the queue)",
@@ -291,7 +293,6 @@ async def remove_one_(
 )
 #
 @remove_g_m.with_command
-@with_strict_stage_cmd_check
 @tj.with_argument('end', converters=int, default=None)
 @tj.with_argument('start', converters=int)
 @tj.as_message_command('bulk', 'b', 'm', 'r', '<>')
@@ -353,9 +354,8 @@ with_common_cmd_check_and_voting = with_cmd_composer(Binds.VOTE, COMMON_CHECKS)
 
 
 @with_common_cmd_check_and_voting
+# -
 @tj.as_slash_command('shuffle', "Shuffles the upcoming tracks")
-#
-@with_common_cmd_check_and_voting
 @tj.as_message_command('shuffle', 'sh', 'shuf', 'rand', 'rd')
 async def shuffle_(ctx: tj.abc.Context, lvc: al.Injected[lv.Lavalink]):
     await shuffle_abs(ctx, lvc)
@@ -378,8 +378,9 @@ async def move_g_m(_: tj.abc.MessageContext):
 
 
 # TODO: Use annotation-based option declaration once declaring positional-only argument is possible
-@move_g_s.with_command
 @with_stage_cmd_check
+# -
+@move_g_s.with_command
 @tj.with_int_slash_option(
     'track',
     "Position of the track? (If not given, the current position)",
@@ -388,7 +389,6 @@ async def move_g_m(_: tj.abc.MessageContext):
 @tj.as_slash_command('last', "Moves the selected track to the end of the queue")
 #
 @move_g_m.with_command
-@with_stage_cmd_check
 @tj.with_argument('track', converters=int, default=None)
 @tj.as_message_command('last', 'l', '>>')
 async def move_last_(
@@ -429,8 +429,9 @@ async def move_last_(
 
 
 # TODO: Use annotation-based option declaration once declaring positional-only argument is possible
-@move_g_s.with_command
 @with_strict_stage_cmd_check
+# -
+@move_g_s.with_command
 @tj.with_int_slash_option(
     'second',
     "Position of the second track? (If not given, the current track)",
@@ -440,7 +441,6 @@ async def move_last_(
 @tj.as_slash_command('swap', "Swaps positions of two tracks in a queue")
 #
 @move_g_m.with_command
-@with_strict_stage_cmd_check
 @tj.with_argument('first', converters=int)
 @tj.with_argument('second', converters=int, default=None)
 @tj.as_message_command('swap', 'sw', '<>', '<->', '<=>')
@@ -502,8 +502,9 @@ async def move_swap_(
 
 
 # TODO: Use annotation-based option declaration once declaring positional-only argument is possible
-@move_g_s.with_command
 @with_strict_stage_cmd_check
+# -
+@move_g_s.with_command
 @tj.with_int_slash_option(
     'track', "Position of the track? (If not given, the current position)", default=None
 )
@@ -511,10 +512,8 @@ async def move_swap_(
 @tj.as_slash_command('insert', "Inserts a track in the queue after a new position")
 #
 @move_g_m.with_command
-@with_strict_stage_cmd_check
 @tj.with_argument('track', converters=int, default=None)
 @tj.with_argument('position', converters=int)
-@tj.with_parser
 @tj.as_message_command('insert', 'ins', 'i', 'v', '^')
 async def move_insert_(
     ctx: tj.abc.Context,
@@ -558,6 +557,7 @@ async def move_insert_(
 
 # TODO: Use annotation-based option declaration once declaring positional-only argument is possible
 @with_common_cmd_check_and_voting
+# -
 @tj.with_str_slash_option(
     'mode',
     "Which mode? (If not given, will cycle between: All > One > Off)",
@@ -567,7 +567,6 @@ async def move_insert_(
 )
 @tj.as_slash_command('repeat', "Select a repeat mode for the queue")
 #
-@with_common_cmd_check_and_voting
 @tj.with_argument('mode', to_repeat_mode, default=None)
 @tj.as_message_command('repeat', 'r', 'rep', 'lp', 'rp', 'loop')
 async def repeat_(

--- a/lyra/src/modules/tuning.py
+++ b/lyra/src/modules/tuning.py
@@ -110,12 +110,11 @@ async def volume_g_m(_: tj.abc.MessageContext):
 
 
 @with_annotated_args
+@with_stage_cmd_check
+# -
 @volume_g_s.with_command
-@with_stage_cmd_check
 @tj.as_slash_command('set', "Set the volume of the bot from 0-10")
-#
 @volume_g_m.with_command
-@with_stage_cmd_check
 @tj.as_message_command('set', '=', '.')
 async def volume_set_(
     ctx: tj.abc.Context,
@@ -140,15 +139,15 @@ async def volume_set_(
 
 
 # TODO: Use annotation-based option declaration once declaring positional-only argument is possible
-@volume_g_s.with_command
 @with_stage_cmd_check
+# -
+@volume_g_s.with_command
 @tj.with_int_slash_option(
     'amount', "Increase by how much (If not given, by 1)", default=1
 )
 @tj.as_slash_command('up', "Increase the bot's volume")
 #
 @volume_g_m.with_command
-@with_stage_cmd_check
 @tj.with_argument('amount', converters=int, default=1)
 @tj.as_message_command('up', 'u', '+', '^')
 async def volume_up_(
@@ -183,15 +182,15 @@ async def volume_up_(
 
 
 # TODO: Use annotation-based option declaration once declaring positional-only argument is possible
-@volume_g_s.with_command
 @with_stage_cmd_check
+# -
+@volume_g_s.with_command
 @tj.with_int_slash_option(
     'amount', "Decrease by how much? (If not given, by 1)", default=1
 )
 @tj.as_slash_command('down', "Decrease the bot's volume")
 #
 @volume_g_m.with_command
-@with_stage_cmd_check
 @tj.with_argument('amount', converters=int, default=1)
 @tj.as_message_command('down', 'd', '-', 'v')
 async def volume_down_(
@@ -226,9 +225,8 @@ async def volume_down_(
 
 
 @with_common_cmd_check
+# -
 @tj.as_slash_command('mute', 'Server mutes the bot')
-#
-@with_common_cmd_check
 @tj.as_message_command('mute', 'm')
 async def mute_(ctx: tj.abc.Context, lvc: al.Injected[lv.Lavalink]):
     """
@@ -241,9 +239,8 @@ async def mute_(ctx: tj.abc.Context, lvc: al.Injected[lv.Lavalink]):
 
 
 @with_common_cmd_check
+# -
 @tj.as_slash_command('unmute', 'Server unmutes the bot')
-#
-@with_common_cmd_check
 @tj.as_message_command('unmute', 'u', 'um')
 async def unmute_(ctx: tj.abc.Context, lvc: al.Injected[lv.Lavalink]):
     """
@@ -256,9 +253,8 @@ async def unmute_(ctx: tj.abc.Context, lvc: al.Injected[lv.Lavalink]):
 
 
 @with_common_cmd_check
+# -
 @tj.as_slash_command('mute-unmute', 'Toggles between server mute and unmuting the bot')
-#
-@with_common_cmd_check
 @tj.as_message_command('mute-unmute', 'muteunmute', 'mm', 'mu', 'tm', 'togglemute')
 async def mute_unmute_(ctx: tj.abc.Context, lvc: al.Injected[lv.Lavalink]):
     """
@@ -290,12 +286,11 @@ valid_presets: t.Final[dict[str, str]] = {
 
 
 @with_annotated_args
+@with_stage_cmd_check
+# -
 @equalizer_g_s.with_command
-@with_stage_cmd_check
 @tj.as_slash_command('preset', "Sets the bot's equalizer to a preset")
-#
 @equalizer_g_m.with_command
-@with_stage_cmd_check
 @tj.as_message_command('preset', 'pre', '=')
 async def equalizer_preset_(
     ctx: tj.abc.Context,


### PR DESCRIPTION
`*` Updated tanjun to `2.6.2a1`
 | `*` Removed all duplicated decorated checks