### PR TITLE
Prioritise perm checks before bindings in commands execution

### DIFF
--- a/lyra/src/lib/_extras_types.py
+++ b/lyra/src/lib/_extras_types.py
@@ -20,6 +20,7 @@ URLstr = str
 _T = t.TypeVar('_T')
 _E = t.TypeVar('_E', bound=Exception)
 _T_co = t.TypeVar('_T_co', covariant=True)
+Coro = t.Coroutine[t.Any, t.Any, _T]
 Option = _T | None
 Result = t.Annotated[_T | t.NoReturn, ...]
 Panic = t.Annotated[_T | t.NoReturn, ...]

--- a/lyra/src/lib/compose.py
+++ b/lyra/src/lib/compose.py
@@ -243,23 +243,22 @@ def with_cmd_composer(
     perms: Option[hkperms] = None,
 ) -> Decorator[_CMD]:
 
-    _checks: list[tj.abc.CheckSig] = []
-    _binds: list[BindSig] = []
+    _checks_binds: list[tj.abc.CheckSig | BindSig] = []
 
     if binds:
-        _binds.extend(parse_binds(binds))
+        _checks_binds.extend(parse_binds(binds))
 
     if checks:
-        _checks.extend(parse_checks(checks))
+        _checks_binds.extend(parse_checks(checks))
 
     if perms:
-        _checks.insert(0, ft.partial(_as_author_permission_check, perms=perms))
+        _checks_binds.insert(0, ft.partial(_as_author_permission_check, perms=perms))
 
     def _with_checks_and_binds(cmd: _CMD, /) -> _CMD:
         cmd.metadata['checks'] = checks
         cmd.metadata['binds'] = binds
         cmd.metadata['perms'] = perms
-        return tj.with_all_checks(*_binds, *_checks, follow_wrapped=True)(cmd)
+        return tj.with_all_checks(*_checks_binds, follow_wrapped=True)(cmd)
 
     return _with_checks_and_binds
 

--- a/lyra/src/lib/extras.py
+++ b/lyra/src/lib/extras.py
@@ -13,6 +13,7 @@ from ._extras_types import (
     Option,
     Decorator,
     _DecoratedT,  # pyright: ignore [reportPrivateUsage]
+    Coro,
     Result,
     Panic,
     NULL,

--- a/lyra/src/lib/utils.py
+++ b/lyra/src/lib/utils.py
@@ -19,6 +19,7 @@ from .extras import (
     Option,
     Result,
     Panic,
+    Coro,
     URLstr,
     AsyncVoidFunction,
     format_flags,
@@ -28,8 +29,6 @@ from .extras import (
 )
 from .dataimpl import LyraDBCollectionType
 
-
-_T = t.TypeVar('_T')
 
 EitherContext = tj.abc.MessageContext | tj.abc.AppCommandContext
 Contextish = tj.abc.Context | hk.ComponentInteraction
@@ -73,7 +72,7 @@ BaseCommandType = tj.abc.ExecutableCommand[tj.abc.Context]
 ParentCommandType: tj.abc.SlashCommandGroup | tj.abc.MessageCommandGroup[
     AsyncVoidFunction
 ]
-BindSig = tj.abc.CheckSig
+BindSig = t.Callable[..., Coro[bool]] | t.Callable[..., bool]
 
 EmojiRefs = t.NewType('EmojiRefs', dict[str, hk.KnownCustomEmoji])
 base_h = tj.AnyHooks()


### PR DESCRIPTION
`*` Combined `_checks` and `_binds` in `with_cmd_composer()` to prioritise perm checks
`+` `Coro` type alias
`?` Removed some unused code