### PR TITLE
Utilises hikari's native event dispatching

### DIFF
--- a/lyra/src/lib/cmd/flags.py
+++ b/lyra/src/lib/cmd/flags.py
@@ -331,7 +331,7 @@ def parse_binds(binds: Binds, /) -> tuple[BindSig, ...]:
         ctx: tj.abc.Context, sig: RequestedToSpeak, /
     ) -> Panic[bool]:
         bot = ctx.client.get_type_dependency(hk.GatewayBot)
-        assert bot
+        assert not isinstance(bot, al.abc.Undefined)
 
         if isinstance(ctx, tj.abc.AppCommandContext):
             await ctx.defer()
@@ -372,7 +372,7 @@ def parse_binds(binds: Binds, /) -> tuple[BindSig, ...]:
 
         ch = ctx.get_channel()
         lvc = ctx.client.get_type_dependency(lv.Lavalink)
-        assert lvc and ch
+        assert not isinstance(lvc, al.abc.Undefined) and ch
 
         conn = lvc.get_guild_gateway_connection_info(ctx.guild_id)
         if conn:

--- a/lyra/src/lib/lava/events.py
+++ b/lyra/src/lib/lava/events.py
@@ -1,0 +1,21 @@
+import abc
+
+import attr as a
+import hikari as hk
+
+# pyright: reportIncompatibleMethodOverride=false
+
+
+@a.define
+class BaseLyraEvent(hk.Event, abc.ABC):
+    app: hk.RESTAware
+
+
+@a.frozen
+class ConnectionCommandsInvokedEvent(BaseLyraEvent):
+    pass
+
+
+@a.frozen
+class TrackStoppedEvent(BaseLyraEvent):
+    pass

--- a/lyra/src/lib/lava/utils.py
+++ b/lyra/src/lib/lava/utils.py
@@ -103,7 +103,7 @@ class QueueList(List[lv.TrackQueue]):
         return None
 
     @property
-    def playing(self) -> bool:
+    def is_playing(self) -> bool:
         return not (self.is_paused or self.is_stopped) and bool(self.current)
 
     @property
@@ -286,8 +286,6 @@ class NodeData:
     nowplaying_components: Option[t.Sequence[hk.api.ActionRowBuilder]] = a.field(
         default=None, init=False
     )
-    track_stopped_fired: bool = a.field(factory=bool, init=False)
-    vc_change_intended: bool = a.field(factory=bool, init=False)
     ...
 
     async def edit_now_playing_components(

--- a/lyra/src/lib/musicutils.py
+++ b/lyra/src/lib/musicutils.py
@@ -83,7 +83,7 @@ async def start_listeners_voting(
 
     cmd_r = get_full_cmd_repr(ctx)
     bot = ctx.client.get_type_dependency(hk.GatewayBot)
-    assert bot
+    assert not isinstance(bot, al.abc.Undefined)
 
     row = (
         ctx.rest.build_action_row()

--- a/lyra/src/lib/utils/__init__.py
+++ b/lyra/src/lib/utils/__init__.py
@@ -388,7 +388,7 @@ def extract_content(msg: hk.Message):
 
 async def start_confirmation_prompt(ctx: tj.abc.Context) -> Result[None]:
     bot = ctx.client.get_type_dependency(hk.GatewayBot)
-    assert bot
+    assert not isinstance(bot, al.abc.Undefined)
 
     cmd_r = get_full_cmd_repr(ctx)
     cmd = t.cast(

--- a/lyra/src/modules/info.py
+++ b/lyra/src/modules/info.py
@@ -151,7 +151,7 @@ async def _search(ctx: EitherContext, query: str, lvc: lv.Lavalink) -> Result[No
     from ..lib.music import play, add_tracks_
 
     erf = ctx.client.get_type_dependency(EmojiRefs)
-    assert ctx.guild_id and erf
+    assert ctx.guild_id and not isinstance(erf, al.abc.Undefined)
 
     query = query.strip("<>|")
 
@@ -160,7 +160,7 @@ async def _search(ctx: EitherContext, query: str, lvc: lv.Lavalink) -> Result[No
     PREVIEW_TIME = 30_000
 
     bot = ctx.client.get_type_dependency(hk.GatewayBot)
-    assert bot
+    assert not isinstance(bot, al.abc.Undefined)
 
     async with trigger_thinking(ctx):
         results = await lvc.auto_search_tracks(query)
@@ -357,7 +357,9 @@ async def queue_(
 
     erf = ctx.client.get_type_dependency(EmojiRefs)
     bot = ctx.client.get_type_dependency(hk.GatewayBot)
-    assert bot and erf
+    assert not isinstance(bot, al.abc.Undefined) and not isinstance(
+        erf, al.abc.Undefined
+    )
 
     def _page_row(*, cancel_b: bool = False):
         row = ctx.rest.build_action_row()
@@ -475,7 +477,9 @@ async def lyrics_(
 
     bot = ctx.client.get_type_dependency(hk.GatewayBot)
     erf = ctx.client.get_type_dependency(EmojiRefs)
-    assert bot and erf
+    assert not isinstance(bot, al.abc.Undefined) and not isinstance(
+        erf, al.abc.Undefined
+    )
 
     if song is None:
         if not ((q := await get_queue(ctx, lvc)) and (np := q.current)):


### PR DESCRIPTION
`+` `lava.events`
 | `+` `ConnectionCommandInvokedEvent`
 | `+` `TrackStoppedEvent`
 | `-` `NodeData.track_stopped_fired&vc_change_intended`
`*` `QueueList.playing` -> `.is_playing`
`?` deps from `.get_type_dependency(...)` will now be asserted with `not isinstance(..., al.abc.Undefined)`