### PR TITLE
Include `/stop` to affect paused now-playing timestamps

### DIFF
--- a/lyra/src/lib/lava/utils.py
+++ b/lyra/src/lib/lava/utils.py
@@ -85,7 +85,7 @@ class QueueList(List[lv.TrackQueue]):
 
     @property
     def np_position(self) -> Option[int]:
-        if self.is_paused:
+        if not self.is_playing:
             return self._paused_np_position
         if not self.current:
             return None

--- a/lyra/src/lib/musicutils.py
+++ b/lyra/src/lib/musicutils.py
@@ -199,7 +199,7 @@ async def generate_queue_embeds(
         )
     )
 
-    color = None if q.is_paused or not q.current else q.curr_t_palette[2]
+    color = q.curr_t_palette[2] if q.is_playing else None
 
     _base_embed = hk.Embed(title="≡♪ Queue", description=desc, color=color,).set_footer(
         f"⌛ {to_stamp(queue_elapsed)} (-{to_stamp(queue_eta)}) / {to_stamp(queue_durr)}ㅤ•ㅤ{q.pos+1} (-{len(q)-q.pos-1}) / {len(q)}"
@@ -225,7 +225,7 @@ async def generate_queue_embeds(
             ),
         )
         .add_field(
-            f"{'🎶 ' if np and not q.is_paused else ''}Now playing",
+            f"{'🎶 ' if q.is_playing else ''}Now playing",
             np_text,
         )
         .add_field(

--- a/lyra/src/lib/playback.py
+++ b/lyra/src/lib/playback.py
@@ -37,6 +37,8 @@ from .lava.events import TrackStoppedEvent
 
 async def stop(g_inf: GuildOrInferable, lvc: lv.Lavalink, /) -> None:
     async with access_queue(g_inf, lvc) as q:
+        if np_pos := q.np_position:
+            q.update_paused_np_position(np_pos)
         q.is_stopped = True
 
     await lvc.stop(infer_guild(g_inf))

--- a/lyra/src/modules/info.py
+++ b/lyra/src/modules/info.py
@@ -85,13 +85,13 @@ async def nowplaying_(
         .replace('─', '▬', progress),
     )
 
-    color = None if q.is_paused else q.curr_t_palette[1]
+    color = q.curr_t_palette[1] if q.is_playing else None
 
     if thumb := q.curr_t_thumbnail:
         thumb = limit_img_size_by_guild(thumb, ctx, ctx.cache)
     embed = (
         hk.Embed(
-            title=f"{'🎶 ' if not q.is_paused else ''}__**`#{q.pos + 1}`**__  {t_info.title}",
+            title=f"{'🎶 ' if q.is_playing else ''}__**`#{q.pos + 1}`**__  {t_info.title}",
             description="%s\n\n%s" % desc,
             url=t_info.uri,
             color=color,


### PR DESCRIPTION
`*` Made now playing related methods use `.is_paused` -> `not .is_playing`
 | `*` `QueueList.np_position`
 | `*` The color and music emoji in the now playing embeds
 | `+` `/stop` will now also call `QueueList.update_paused_np_position(np_pos)`