### PR TITLE
Fixed outdated code & `/remove bulk` not sending any warnings

### DIFF
--- a/lyra/src/client.py
+++ b/lyra/src/client.py
@@ -18,11 +18,11 @@ from .lib import (
     repeat_emojis,
     EmojiRefs,
     base_h,
+    __init_mongo_client__,
     restricts_c,
     inj_glob,
     lgfmt,
 )
-from .lib.dataimpl import __init_mongo_client__
 
 # pyright: reportUnknownMemberType=false
 
@@ -59,7 +59,10 @@ _client = globs.__init_client__(
     .set_dms_enabled_for_app_cmds(False)
 )
 
-activity = hk.Activity(name='/play', type=hk.ActivityType.LISTENING)
+activity = hk.Activity(
+    name="%s" % '/play',
+    type=hk.ActivityType.LISTENING,
+)
 
 emoji_refs = EmojiRefs({})
 

--- a/lyra/src/lib/__init__.py
+++ b/lyra/src/lib/__init__.py
@@ -10,4 +10,4 @@ from .lava.utils import (
     get_data,
     repeat_emojis,
 )
-from .dataimpl import LyraDBClientType, LyraDBCollectionType
+from .dataimpl import LyraDBClientType, LyraDBCollectionType, __init_mongo_client__

--- a/lyra/src/lib/cmd/compose.py
+++ b/lyra/src/lib/cmd/compose.py
@@ -8,6 +8,7 @@ import lavasnek_rs as lv
 from hikari.permissions import Permissions as hkperms
 
 from .ids import CommandIdentifier
+from .types import GenericCommandType
 from .flags import (
     Binds,
     Checks,
@@ -20,7 +21,6 @@ from .flags import (
 )
 from ..utils import (
     BindSig,
-    GenericCommandType,
     Contextish,
     get_client,
     fetch_permissions,

--- a/lyra/src/lib/cmd/ids.py
+++ b/lyra/src/lib/cmd/ids.py
@@ -34,6 +34,7 @@ class CommandIdentifier(e.Enum):
     QUEUE = e.auto()
     LYRICS = e.auto()
 
+    ABOUT = e.auto()  # TODO: Implement `/about`
     PING = e.auto()
     HELP = e.auto()  # TODO: #27 Implement `/help`
 

--- a/lyra/src/lib/cmd/types.py
+++ b/lyra/src/lib/cmd/types.py
@@ -1,0 +1,33 @@
+import typing as t
+
+import hikari as hk
+import tanjun as tj
+
+from ..extras.types import AsyncVoidAnySig
+
+
+CommandType = tj.abc.ExecutableCommand
+GenericCommandType = CommandType[tj.abc.Context]
+MenuCommandType = tj.abc.MenuCommand
+GenericMenuCommandType = MenuCommandType[
+    AsyncVoidAnySig, t.Literal[hk.CommandType.MESSAGE]
+]
+MessageCommandType = tj.abc.MessageCommand
+GenericMessageCommandType = MessageCommandType[AsyncVoidAnySig]
+MessageCommandGroupType = tj.abc.MessageCommandGroup
+GenericMessageCommandGroupType = MessageCommandGroupType[AsyncVoidAnySig]
+GenericAnyMessageCommandType = (
+    GenericMessageCommandType | GenericMessageCommandGroupType
+)
+SlashCommandType = tj.abc.SlashCommand
+GenericSlashCommandType = SlashCommandType[AsyncVoidAnySig]
+SlashCommandGroupType = tj.abc.SlashCommandGroup
+GenericAnySlashCommandType = GenericSlashCommandType | tj.abc.SlashCommandGroup
+GenericAnyCommandType = (
+    GenericMenuCommandType | GenericAnySlashCommandType | GenericAnyMessageCommandType
+)
+AlmostGenericAnyCommandType = (
+    tj.abc.BaseSlashCommand | GenericMenuCommandType | GenericMessageCommandType
+)
+GenericAnyChildCommandType = GenericSlashCommandType | GenericMessageCommandType
+GenericAnyCommandGroupType = tj.abc.SlashCommandGroup | GenericMessageCommandGroupType

--- a/lyra/src/lib/connections.py
+++ b/lyra/src/lib/connections.py
@@ -190,13 +190,13 @@ async def cleanup(
     lvc: lv.Lavalink,
     /,
     *,
-    also_disconns: bool = True,
+    also_disconn: bool = True,
 ) -> None:
     async with access_queue(guild, lvc) as q:
         q.clr()
     await lvc.destroy(guild)
     if shards:
-        if also_disconns:
+        if also_disconn:
             await shards.update_voice_state(guild, None)
         await lvc.wait_for_connection_info_remove(guild)
     await lvc.remove_guild_node(guild)

--- a/lyra/src/lib/queue.py
+++ b/lyra/src/lib/queue.py
@@ -46,7 +46,7 @@ from .lava.utils import (
     get_data,
     set_data,
 )
-from .playback import back, skip, while_stop
+from .playback import back, skip, while_stop, set_pause
 from .dataimpl import LyraDBClientType
 
 
@@ -194,8 +194,6 @@ async def add_tracks_(
 async def remove_track(
     ctx: tj.abc.Context, track: Option[str], lvc: lv.Lavalink, /
 ) -> Result[lv.TrackQueue]:
-    from .playback import while_stop, skip
-
     assert ctx.guild_id
 
     d = await get_data(ctx.guild_id, lvc)
@@ -236,7 +234,7 @@ async def remove_track(
     q.sub(rm)
 
     logger.info(
-        f"In guild {ctx.guild_id} track [{i: >3}+1/{len(q)}] removed: '{rm.track.info.title}'"
+        f"In guild {ctx.guild_id} track [{i: >3}/{len(q): >3}] removed: '{rm.track.info.title}'"
     )
 
     await set_data(ctx.guild_id, lvc, d)
@@ -246,8 +244,6 @@ async def remove_track(
 async def remove_tracks(
     ctx: tj.abc.Context, start: int, end: int, lvc: lv.Lavalink, /
 ) -> Result[list[lv.TrackQueue]]:
-    from .playback import while_stop, set_pause
-
     assert ctx.guild_id
 
     d = await get_data(ctx.guild_id, lvc)
@@ -270,7 +266,7 @@ async def remove_tracks(
     q.sub(*rm)
 
     logger.info(
-        f"""In guild {ctx.guild_id} tracks [{i_s: >3}~{i_e: >3}/{len(q)}] removed: '{', '.join(("'%s'" %  t.track.info.title) for t in rm)}'"""
+        f"""In guild {ctx.guild_id} tracks [{i_s: >3}~{i_e: >3}/{len(q): >3}] removed: '{', '.join(("'%s'" %  t.track.info.title) for t in rm)}'"""
     )
 
     await set_data(ctx.guild_id, lvc, d)

--- a/lyra/src/lib/utils/__init__.py
+++ b/lyra/src/lib/utils/__init__.py
@@ -18,11 +18,6 @@ from .vars import RESTRICTOR, base_h, EmojiRefs, DJ_PERMS, dj_perms_fmt, guild_c
 from .types import (
     Contextish,
     EitherContext,
-    GenericCommandType,
-    GenericMenuCommandType,
-    GenericMessageCommandGroupType,
-    GenericMessageCommandType,
-    GenericSlashCommandType,
     GuildOrInferable,
     GuildOrRESTInferable,
     GuildInferableEvents,
@@ -39,6 +34,12 @@ from .types import (
     with_annotated_args,
 )
 from ..cmd import get_full_cmd_repr
+from ..cmd.types import (
+    GenericMenuCommandType,
+    GenericMessageCommandGroupType,
+    GenericMessageCommandType,
+    GenericSlashCommandType,
+)
 from ..consts import TIMEOUT, Q_CHUNK
 from ..errors import BaseLyraException, CommandCancelled
 from ..extras import (

--- a/lyra/src/lib/utils/types.py
+++ b/lyra/src/lib/utils/types.py
@@ -3,7 +3,7 @@ import typing as t
 import hikari as hk
 import tanjun as tj
 
-from ..extras.types import Coro, AsyncVoidAnySig
+from ..extras.types import Coro
 
 
 EitherContext = tj.abc.MessageContext | tj.abc.AppCommandContext
@@ -44,28 +44,6 @@ EditableComponentsType = ButtonBuilderType | SelectMenuBuilderType
 MentionableType = hk.GuildChannel | hk.Role | hk.Member
 PartialMentionableType = hk.PartialUser | hk.PartialRole | hk.PartialChannel
 JoinableChannelType = hk.GuildVoiceChannel | hk.GuildStageChannel
-
-CommandType = tj.abc.ExecutableCommand
-GenericCommandType = CommandType[tj.abc.Context]
-MenuCommandType = tj.abc.MenuCommand
-GenericMenuCommandType = MenuCommandType[
-    AsyncVoidAnySig, t.Literal[hk.CommandType.MESSAGE]
-]
-MessageCommandType = tj.abc.MessageCommand
-GenericMessageCommandType = MessageCommandType[AsyncVoidAnySig]
-MessageCommandGroupType = tj.abc.MessageCommandGroup
-GenericMessageCommandGroupType = MessageCommandGroupType[AsyncVoidAnySig]
-GenericAnyMessageCommandType = (
-    GenericMessageCommandType | GenericMessageCommandGroupType
-)
-SlashCommandType = tj.abc.SlashCommand
-GenericSlashCommandType = SlashCommandType[AsyncVoidAnySig]
-SlashCommandGroupType = tj.abc.SlashCommandGroup
-GenericAnySlashCommandType = GenericSlashCommandType | tj.abc.SlashCommandGroup
-GenericAnyCommandType = (
-    GenericMenuCommandType | GenericAnySlashCommandType | GenericAnyMessageCommandType
-)
-ParentCommandType: tj.abc.SlashCommandGroup | GenericMessageCommandGroupType
 
 BindSig = t.Callable[..., Coro[bool]] | t.Callable[..., bool]
 

--- a/lyra/src/modules/connections.py
+++ b/lyra/src/modules/connections.py
@@ -89,7 +89,7 @@ async def on_voice_state_update(
     # print(conn_cmd_invoked)
     if not conn_cmd_invoked and old and old.user_id == bot_u.id:
         if not new.channel_id:
-            await cleanup(event.guild_id, client.shards, lvc, also_disconns=False)
+            await cleanup(event.guild_id, client.shards, lvc, also_disconn=False)
             await bot.rest.create_message(
                 out_ch,
                 f"🥀📎 ~~<#{(_vc := old.channel_id)}>~~ `(Bot was forcefully disconnected)`",

--- a/lyra/src/modules/info.py
+++ b/lyra/src/modules/info.py
@@ -6,6 +6,7 @@ import alluka as al
 import lavasnek_rs as lv
 import tanjun.annotations as ja
 
+from ..lib.cmd import get_full_cmd_repr_from_identifier
 from ..lib.cmd.ids import CommandIdentifier as C
 from ..lib.cmd.compose import with_identifier
 from ..lib.utils import (
@@ -21,7 +22,7 @@ from ..lib.utils import (
     disable_components,
     with_annotated_args,
 )
-from ..lib.playback import stop, unstop
+from ..lib.music import stop, unstop
 from ..lib.musicutils import generate_queue_embeds, __init_component__
 from ..lib.errors import QueryEmpty, LyricsNotFound
 from ..lib.extras import Option, Result, to_stamp, wr, get_lyrics
@@ -165,12 +166,14 @@ async def _search(ctx: EitherContext, query: str, lvc: lv.Lavalink) -> Result[No
     async with trigger_thinking(ctx):
         results = await lvc.auto_search_tracks(query)
     if results.load_type in {'TRACK_LOADED', 'PLAYLIST_LOADED'}:
+        play_r = get_full_cmd_repr_from_identifier(C.PLAY, ctx)
+
         await play(ctx, lvc, tracks=results, respond=True)
         await say(
             ctx,
             hidden=True,
             follow_up=True,
-            content="💡 This is already a song link. *Did you mean to use `/play` instead?*",
+            content=f"💡 This is already a song link. *Did you mean to use {play_r} instead?*",
         )
         return
 

--- a/lyra/src/modules/playback.py
+++ b/lyra/src/modules/playback.py
@@ -114,8 +114,6 @@ async def on_voice_state_update(
         return
     assert _conn is not None
 
-    from .playback import set_pause
-
     old_is_stage = (
         None
         if not (old and old.channel_id)
@@ -433,7 +431,10 @@ with_re_cmd_check_and_voting = with_cmd_composer(
 
 @with_re_cmd_check_and_voting(C.RESTART)
 # -
-@tj.as_slash_command('restart', "Restarts the current track; Equivalent to /seek 0:00")
+@tj.as_slash_command(
+    'restart',
+    "Restarts the current track; Equivalent to %s 0:00" % '/seek',
+)
 @tj.as_message_command('restart', 're', '<')
 async def restart_(ctx: tj.abc.Context, lvc: al.Injected[lv.Lavalink]):
     assert ctx.guild_id


### PR DESCRIPTION
`*` `get_pref()` now only do message cmds prefxies
`*` `get_full_cmd_repr(...)`
 | `+` typing overloads for the func
 | `*` allowed ctx obj to be `None`
`*` `get_full_cmd_repr_from_identifier(...)`
 | `*` allowed ctx obj to be `None` or client
`*` `get_full_cmd_repr_from_identifier(...)` will now use `recurse_cmds(...)`
 | `+` `extras.recurse(...)`
 | `*` metadata setting in `misc` will now use `recurse_cmds(...)`
`~` moved cmd type aliases from `utils` to `cmd.types`
`+` `CommandIdentifier.ABOUT`
`*` `extras.flatten()` will now return an iterator instead of a tuple
`*` cleaned up some imports
`cleanup(also_disconns)` -> `also_disconn`
`*` replaced some old cmd repr to use `get_full_cmd_repr_from_identifier(...)`
`!` fixed `/remove bulk` not showing info msg when `/clear` should be used