### PR TITLE
Fixed menu commands not working

### DIFF
--- a/lyra/src/modules/info.py
+++ b/lyra/src/modules/info.py
@@ -139,8 +139,8 @@ async def search_(
 @tj.as_message_menu('Search this song up')
 async def search_c(
     ctx: tj.abc.MenuContext,
-    lvc: al.Injected[lv.Lavalink],
     msg: hk.Message,
+    lvc: al.Injected[lv.Lavalink],
 ) -> None:
     if not (cnt := extract_content(msg)):
         await err_say(ctx, content="❌ Cannot process an empty message")

--- a/lyra/src/modules/queue.py
+++ b/lyra/src/modules/queue.py
@@ -193,8 +193,8 @@ async def play_m(
 @tj.as_message_menu("Enqueue this song")
 async def play_c(
     ctx: tj.abc.MenuContext,
-    lvc: al.Injected[lv.Lavalink],
     msg: hk.Message,
+    lvc: al.Injected[lv.Lavalink],
 ) -> None:
     cnt = extract_content(msg)
     song = concat_audio(msg, cnt)


### PR DESCRIPTION
Fixes #50
* moved `msg` param below `lvc` in menu cmd callbacks