### PR TITLE
Fixed incorrect menu cmd reprs

### DIFF
--- a/lyra/src/lib/extras/__init__.py
+++ b/lyra/src/lib/extras/__init__.py
@@ -235,15 +235,15 @@ def flatten(iter_iters: t.Iterable[t.Iterable[_FE]], /) -> t.Iterator[_FE]:
 
 _RE = t.TypeVar('_RE')
 _RecurseT = t.Iterable[_RE | '_RecurseT']
-_FlattenedT = t.TypeVar('_FlattenedT')
-FlattenerSig = t.Callable[[_FlattenedT], t.Iterator[_RE]]
+_RecursedT = t.TypeVar('_RecursedT')
+RecurserSig = t.Callable[[_RecursedT], t.Iterator[_RE]]
 
 
 def recurse(
     iters: _RecurseT[_RE],
     /,
-    recursed: Option[type[_FlattenedT]] = None,
-    recurser: Option[FlattenerSig[_FlattenedT, _RE]] = None,
+    recursed: Option[type[_RecursedT]] = None,
+    recurser: Option[RecurserSig[_RecursedT, _RE]] = None,
     *,
     include_recursed: bool = False,
 ) -> t.Iterator[_RE]:
@@ -252,7 +252,7 @@ def recurse(
         if isinstance(_r, recursed or t.Iterable):
             if include_recursed:
                 yield t.cast(_RE, _r)
-            yield from recurser(t.cast(_FlattenedT, _r))
+            yield from recurser(t.cast(_RecursedT, _r))
         else:
             yield t.cast(_RE, _r)
 

--- a/lyra/src/lib/lava/__init__.py
+++ b/lyra/src/lib/lava/__init__.py
@@ -71,29 +71,21 @@ class EventHandler(BaseEventHandler):
             if not d.queue.current:
                 return
             embed = await generate_nowplaying_embed(event.guild_id, client.cache, lvc)
-            controls = client.rest.build_action_row()
-            (
-                controls.add_button(hk.ButtonStyle.SECONDARY, 'lyra_shuffle')
+            controls = (
+                client.rest.build_action_row()
+                .add_button(hk.ButtonStyle.SECONDARY, 'lyra_shuffle')
                 .set_emoji(erf['shuffle_b'])
                 .add_to_container()
-            )
-            (
-                controls.add_button(hk.ButtonStyle.SECONDARY, 'lyra_previous')
+                .add_button(hk.ButtonStyle.SECONDARY, 'lyra_previous')
                 .set_emoji(erf['previous_b'])
                 .add_to_container()
-            )
-            (
-                controls.add_button(hk.ButtonStyle.PRIMARY, 'lyra_playpause')
+                .add_button(hk.ButtonStyle.PRIMARY, 'lyra_playpause')
                 .set_emoji(erf['resume_b'])
                 .add_to_container()
-            )
-            (
-                controls.add_button(hk.ButtonStyle.SECONDARY, 'lyra_skip')
+                .add_button(hk.ButtonStyle.SECONDARY, 'lyra_skip')
                 .set_emoji(erf['skip_b'])
                 .add_to_container()
-            )
-            (
-                controls.add_button(hk.ButtonStyle.SUCCESS, 'lyra_repeat')
+                .add_button(hk.ButtonStyle.SUCCESS, 'lyra_repeat')
                 .set_emoji(get_repeat_emoji(q))
                 .add_to_container()
             )

--- a/lyra/src/modules/info.py
+++ b/lyra/src/modules/info.py
@@ -188,15 +188,15 @@ async def _search(ctx: EitherContext, query: str, lvc: lv.Lavalink) -> Result[No
         )
     )
 
-    pre_row_1 = ctx.rest.build_action_row()
+    prv_row_1 = ctx.rest.build_action_row()
     components: list[hk.api.ActionRowBuilder] = []
 
-    for i in (pre_row_1_ := map(str, range(1, 1 + len(queried[:5])))):
-        pre_row_1.add_button(hk.ButtonStyle.SECONDARY, i).set_label(
+    for i in (prv_row_1_ := map(str, range(1, 1 + len(queried[:5])))):
+        prv_row_1.add_button(hk.ButtonStyle.SECONDARY, i).set_label(
             i
         ).add_to_container()
-    if pre_row_1_:
-        components.append(pre_row_1)
+    if prv_row_1_:
+        components.append(prv_row_1)
 
         pre_row_2 = ctx.rest.build_action_row()
         for j in (pre_row_2_ := map(str, range(6, 6 + len(queried[5:10])))):
@@ -206,17 +206,18 @@ async def _search(ctx: EitherContext, query: str, lvc: lv.Lavalink) -> Result[No
         if pre_row_2_:
             components.append(pre_row_2)
 
-    ops_row = ctx.rest.build_action_row()
-    ops_row.add_button(hk.ButtonStyle.SUCCESS, 'enqueue').set_label(
-        "＋ Enqueue"
-    ).add_to_container()
-
-    ops_row.add_button(hk.ButtonStyle.PRIMARY, 'link').set_label(
-        "Get Link"
-    ).add_to_container()
-    ops_row.add_button(hk.ButtonStyle.DANGER, 'cancel').set_emoji(
-        erf['exit_b']
-    ).add_to_container()
+    ops_row = (
+        ctx.rest.build_action_row()
+        .add_button(hk.ButtonStyle.SUCCESS, 'enqueue')
+        .set_label("＋ Enqueue")
+        .add_to_container()
+        .add_button(hk.ButtonStyle.PRIMARY, 'link')
+        .set_label("Get Link")
+        .add_to_container()
+        .add_button(hk.ButtonStyle.DANGER, 'cancel')
+        .set_emoji(erf['exit_b'])
+        .add_to_container()
+    )
     components.append(ops_row)
 
     embed = hk.Embed(

--- a/lyra/src/modules/misc.py
+++ b/lyra/src/modules/misc.py
@@ -189,7 +189,7 @@ async def help_(
             or '` - `',
         )
         .set_footer(
-            f"For more info about the glossary and meanings of the symbols above, please check {get_full_cmd_repr_from_identifier(C.ABOUT, pretty=False)}"
+            f"For more info about the glossary and meanings of the symbols above, please check {get_full_cmd_repr_from_identifier(C.ABOUT, ctx, pretty=False)}"
         )
     )
     await say(ctx, embed=embed)


### PR DESCRIPTION
`*` `get_pref(...)` -> `get_implied_prefix(...)`
 | `*` now also accepts cmd objs
 | `+` now support returning `'/'` and `'|>'` for slash and menu cmds respectively
`-` removed deprecated overloads from `get_full_cmd_repr_from_identifier(...)`
`?` some minor code optimizations & refractoring
`?` `_FlattenedT` -> `_RecursedT`, `FlattenerSig` -> `RecurserSig`
`?` renamed some vars with more meaningful names