### PR TITLE
Utilised Tanjun's new features to reduce boilerplate (2)

### DIFF
--- a/lyra/requirements.txt
+++ b/lyra/requirements.txt
@@ -1,7 +1,7 @@
 alluka==0.1.1
 attrs
 hikari==2.0.0.dev110
-hikari-tanjun==2.6.2a1
+hikari-tanjun==2.7.0a1
 lyricsgenius==3.0.1
 PyYAML
 requests

--- a/lyra/src/lib/cmd/__init__.py
+++ b/lyra/src/lib/cmd/__init__.py
@@ -17,14 +17,14 @@ from .types import (
     SlashCommandGroupType,
     SlashCommandType,
 )
-from ..utils.types import (
-    Contextish,
+from ..utils import (
+    ContextishType,
 )
 from ..extras import RecurserSig, recurse
 from ..extras.types import Option
 
 
-def get_implied_prefix(ctx_cmd: Contextish | GenericAnyCommandType, /) -> str:
+def get_implied_prefix(ctx_cmd: ContextishType | GenericAnyCommandType, /) -> str:
     if isinstance(ctx_cmd, tj.abc.MessageContext):
         return next(iter(ctx_cmd.client.prefixes))
     if isinstance(
@@ -107,7 +107,7 @@ def get_full_cmd_repr(
 
 
 def get_full_cmd_repr(
-    _ctx_: Option[Contextish],
+    _ctx_: Option[ContextishType],
     /,
     cmd: Option[GenericAnyCommandType] = None,
     *,
@@ -132,7 +132,7 @@ def get_full_cmd_repr(
 
 @t.overload
 def get_full_cmd_repr_from_identifier(
-    identifier: CommandIdentifier, /, ctx_: Contextish, *, pretty: bool = True
+    identifier: CommandIdentifier, /, ctx_: ContextishType, *, pretty: bool = True
 ) -> str:
     ...
 
@@ -147,7 +147,7 @@ def get_full_cmd_repr_from_identifier(
 def get_full_cmd_repr_from_identifier(
     identifier: CommandIdentifier,
     /,
-    _ctx_c: Contextish | tj.abc.Client,
+    _ctx_c: ContextishType | tj.abc.Client,
     *,
     pretty: bool = True,
 ):

--- a/lyra/src/lib/cmd/compose.py
+++ b/lyra/src/lib/cmd/compose.py
@@ -21,7 +21,7 @@ from .flags import (
 )
 from ..utils import (
     BindSig,
-    Contextish,
+    ContextishType,
     get_client,
     fetch_permissions,
     start_confirmation_prompt,
@@ -46,7 +46,9 @@ from ..errors.expects import BindErrorExpects, CheckErrorExpects
 from ..lava.utils import get_queue
 
 
-async def others_not_in_vc_check(ctx_: Contextish, lvc: lv.Lavalink, /) -> Result[bool]:
+async def others_not_in_vc_check(
+    ctx_: ContextishType, lvc: lv.Lavalink, /
+) -> Result[bool]:
     assert ctx_.guild_id
 
     conn = t.cast(
@@ -72,7 +74,7 @@ def with_cb_check(
     P = t.ParamSpec('P')
 
     async def _check_in_vc(
-        ctx_: Contextish, conn: ConnectionInfo, /, *, perms: hkperms = DJ_PERMS
+        ctx_: ContextishType, conn: ConnectionInfo, /, *, perms: hkperms = DJ_PERMS
     ):
         member = ctx_.member
         assert ctx_.guild_id
@@ -94,7 +96,7 @@ def with_cb_check(
         if not (auth_perms & (perms | hkperms.ADMINISTRATOR)) and not author_in_voice:
             raise AlreadyConnected(channel)
 
-    async def check_in_vc(ctx_: Contextish, lvc: lv.Lavalink):
+    async def check_in_vc(ctx_: ContextishType, lvc: lv.Lavalink):
         assert ctx_.guild_id
 
         conn = t.cast(
@@ -103,7 +105,7 @@ def with_cb_check(
         assert conn is not None
         await _check_in_vc(ctx_, conn)
 
-    async def check_np_yours(ctx_: Contextish, lvc: lv.Lavalink):
+    async def check_np_yours(ctx_: ContextishType, lvc: lv.Lavalink):
         assert ctx_.member
 
         auth_perms = await fetch_permissions(ctx_)
@@ -114,7 +116,7 @@ def with_cb_check(
         ):
             raise PlaybackChangeRefused(q.current)
 
-    async def check_can_seek_any(ctx_: Contextish, lvc: lv.Lavalink):
+    async def check_can_seek_any(ctx_: ContextishType, lvc: lv.Lavalink):
         assert ctx_.member
 
         auth_perms = await fetch_permissions(ctx_)
@@ -124,26 +126,26 @@ def with_cb_check(
             if ctx_.member.id != np.requester:
                 raise PlaybackChangeRefused(np)
 
-    async def check_stop(ctx_: Contextish, lvc: lv.Lavalink):
+    async def check_stop(ctx_: ContextishType, lvc: lv.Lavalink):
         if (await get_queue(ctx_, lvc)).is_stopped:
             raise TrackStopped
 
-    async def check_conn(ctx_: Contextish, lvc: lv.Lavalink):
+    async def check_conn(ctx_: ContextishType, lvc: lv.Lavalink):
         assert ctx_.guild_id
 
         conn = lvc.get_guild_gateway_connection_info(ctx_.guild_id)
         if not conn:
             raise NotConnected
 
-    async def check_queue(ctx_: Contextish, lvc: lv.Lavalink):
+    async def check_queue(ctx_: ContextishType, lvc: lv.Lavalink):
         if not await get_queue(ctx_, lvc):
             raise QueueEmpty
 
-    async def check_playing(ctx_: Contextish, lvc: lv.Lavalink):
+    async def check_playing(ctx_: ContextishType, lvc: lv.Lavalink):
         if not (await get_queue(ctx_, lvc)).current:
             raise NotPlaying
 
-    async def check_pause(ctx_: Contextish, lvc: lv.Lavalink):
+    async def check_pause(ctx_: ContextishType, lvc: lv.Lavalink):
         if (await get_queue(ctx_, lvc)).is_paused:
             raise TrackPaused
 
@@ -153,7 +155,7 @@ def with_cb_check(
         @ft.wraps(func)
         async def inner(*args: P.args, **kwargs: P.kwargs) -> None:
 
-            ctx_ = next((a for a in args if isinstance(a, Contextish)), NULL)
+            ctx_ = next((a for a in args if isinstance(a, ContextishType)), NULL)
 
             assert ctx_, "Missing a Contextish object"
             assert ctx_.guild_id

--- a/lyra/src/lib/cmd/flags.py
+++ b/lyra/src/lib/cmd/flags.py
@@ -12,7 +12,7 @@ from ..utils import (
     DJ_PERMS,
     TIMEOUT,
     BindSig,
-    Contextish,
+    ContextishType,
     ConnectionInfo,
     delete_after,
     fetch_permissions,
@@ -81,7 +81,7 @@ class Binds(AutoDocsFlag):
     VOTE = """Binds a voting prompt to be used when needed"""
 
 
-async def speaker_check(ctx_: Contextish, /) -> Result[bool]:
+async def speaker_check(ctx_: ContextishType, /) -> Result[bool]:
     assert ctx_.guild_id
 
     client = get_client(ctx_)

--- a/lyra/src/lib/connections.py
+++ b/lyra/src/lib/connections.py
@@ -14,7 +14,7 @@ from .utils import (
     DJ_PERMS,
     RESTRICTOR,
     ConnectionInfo,
-    Contextish,
+    ContextishType,
     err_say,
     fetch_permissions,
     get_client,
@@ -249,7 +249,7 @@ async def join_impl_precaught(
 
 
 async def others_not_in_vc_check_impl(
-    ctx_: Contextish, conn: ConnectionInfo, /, *, perms: hkperms = DJ_PERMS
+    ctx_: ContextishType, conn: ConnectionInfo, /, *, perms: hkperms = DJ_PERMS
 ) -> Result[bool]:
     auth_perms = await fetch_permissions(ctx_)
     member = ctx_.member

--- a/lyra/src/lib/errors/expects.py
+++ b/lyra/src/lib/errors/expects.py
@@ -27,7 +27,7 @@ from . import (
 )
 from ..cmd import get_full_cmd_repr_from_identifier
 from ..cmd.ids import CommandIdentifier
-from ..utils import Contextish, dj_perms_fmt, err_say, get_rest, say
+from ..utils import ContextishType, dj_perms_fmt, err_say, get_rest, say
 from ..extras import Result, format_flags
 
 
@@ -36,7 +36,7 @@ ExpectSig = t.Callable[[], t.Awaitable[None]]
 
 @a.frozen
 class BaseErrorExpects(abc.ABC):
-    context: Contextish
+    context: ContextishType
 
     @abc.abstractmethod
     def match_expect(self, error: Exception, /) -> Result[ExpectSig]:
@@ -54,7 +54,7 @@ class BaseErrorExpects(abc.ABC):
 
 @a.frozen
 class CheckErrorExpects(BaseErrorExpects):
-    context: Contextish
+    context: ContextishType
 
     async def expect_network_error(self):
         await err_say(self.context, content="⁉️ A network error has occurred")
@@ -192,7 +192,7 @@ class CheckErrorExpects(BaseErrorExpects):
 
 @a.frozen
 class BindErrorExpects(BaseErrorExpects):
-    context: Contextish
+    context: ContextishType
 
     async def expect_command_cancelled(self):
         await err_say(self.context, follow_up=False, content="🛑 Cancelled the command")

--- a/lyra/src/lib/extras/__init__.py
+++ b/lyra/src/lib/extras/__init__.py
@@ -21,7 +21,7 @@ from .types import (
     Panic,
     NULL,
     RGBTriplet,
-    MaybeIterable,
+    IterableOr,
     MapSig,
     AsyncVoidAnySig,
     URLstr,

--- a/lyra/src/lib/extras/types.py
+++ b/lyra/src/lib/extras/types.py
@@ -30,7 +30,8 @@ Result = t.Annotated[_T | t.NoReturn, ...]
 OptionResult = Option[Result[_T]]
 Panic = t.Annotated[_T | t.NoReturn, ...]
 Require = t.Annotated[_T_co, ...]
-MaybeIterable = _T | t.Iterable[_T]
+AnyOr = t.Any | _T
+IterableOr = _T | t.Iterable[_T]
 
 KeySig = t.Callable[[__E], _KE]
 MapSig = t.Callable[[_T], _T]

--- a/lyra/src/lib/lava/utils.py
+++ b/lyra/src/lib/lava/utils.py
@@ -11,7 +11,7 @@ import attr as a
 import hikari as hk
 import lavasnek_rs as lv
 
-from ..utils import GuildOrInferable, infer_guild, limit_img_size_by_guild
+from ..utils import MaybeGuildIDAware, IntCastable, infer_guild, limit_img_size_by_guild
 from ..errors import NotConnected, QueueEmpty
 from ..consts import STOP_REFRESH
 from ..extras import (
@@ -340,8 +340,8 @@ async def set_data(
 
 
 @ctxlib.asynccontextmanager
-async def access_queue(g_inf: GuildOrInferable, lvc: lv.Lavalink, /):
-    data = await get_data(g := infer_guild(g_inf), lvc)
+async def access_queue(g_: IntCastable | MaybeGuildIDAware, lvc: lv.Lavalink, /):
+    data = await get_data(g := infer_guild(g_), lvc)
     try:
         yield data.queue
     finally:
@@ -349,8 +349,8 @@ async def access_queue(g_inf: GuildOrInferable, lvc: lv.Lavalink, /):
 
 
 @ctxlib.asynccontextmanager
-async def access_equalizer(g_inf: GuildOrInferable, lvc: lv.Lavalink, /):
-    data = await get_data(g := infer_guild(g_inf), lvc)
+async def access_equalizer(g_: IntCastable | MaybeGuildIDAware, lvc: lv.Lavalink, /):
+    data = await get_data(g := infer_guild(g_), lvc)
     try:
         yield data.equalizer
     finally:
@@ -358,16 +358,18 @@ async def access_equalizer(g_inf: GuildOrInferable, lvc: lv.Lavalink, /):
 
 
 @ctxlib.asynccontextmanager
-async def access_data(g_inf: GuildOrInferable, lvc: lv.Lavalink, /):
-    data = await get_data(g := infer_guild(g_inf), lvc)
+async def access_data(g_: IntCastable | MaybeGuildIDAware, lvc: lv.Lavalink, /):
+    data = await get_data(g := infer_guild(g_), lvc)
     try:
         yield data
     finally:
         await set_data(g, lvc, data)
 
 
-async def get_queue(g_inf: GuildOrInferable, lvc: lv.Lavalink, /) -> Panic[QueueList]:
-    return (await get_data(infer_guild(g_inf), lvc)).queue
+async def get_queue(
+    g_: IntCastable | MaybeGuildIDAware, lvc: lv.Lavalink, /
+) -> Panic[QueueList]:
+    return (await get_data(infer_guild(g_), lvc)).queue
 
 
 def get_repeat_emoji(q: QueueList, /):
@@ -416,9 +418,11 @@ async def generate_nowplaying_embed(
     return embed
 
 
-async def wait_until_current_track_valid(g_inf: GuildOrInferable, lvc: lv.Lavalink, /):
+async def wait_until_current_track_valid(
+    g_: IntCastable | MaybeGuildIDAware, lvc: lv.Lavalink, /
+):
     while True:
-        d = await get_data(infer_guild(g_inf), lvc)
+        d = await get_data(infer_guild(g_), lvc)
         if d.queue.current and d.out_channel_id:
             return
         await asyncio.sleep(STOP_REFRESH)

--- a/lyra/src/lib/musicutils.py
+++ b/lyra/src/lib/musicutils.py
@@ -5,8 +5,6 @@ import tanjun as tj
 import alluka as al
 import lavasnek_rs as lv
 
-from .extras.types import MaybeIterable
-
 from .utils import (
     Q_CHUNK,
     TIMEOUT,
@@ -17,7 +15,17 @@ from .utils import (
     err_say,
     say,
 )
-from .extras import Result, Option, MapSig, chunk, chunk_b, map_in_place, to_stamp, wr
+from .extras import (
+    Result,
+    Option,
+    MapSig,
+    IterableOr,
+    chunk,
+    chunk_b,
+    map_in_place,
+    to_stamp,
+    wr,
+)
 from .errors import (
     NotConnected,
     VotingTimeout,
@@ -41,8 +49,8 @@ def __init_component__(
     *,
     guild_check: bool = True,
     music_hook: bool = True,
-    other_checks: MaybeIterable[tj.abc.CheckSig] = (),
-    other_hooks: MaybeIterable[tj.abc.Hooks[tj.abc.Context]] = (),
+    other_checks: IterableOr[tj.abc.CheckSig] = (),
+    other_hooks: IterableOr[tj.abc.Hooks[tj.abc.Context]] = (),
 ):
     comp = tj.Component(name=dunder_name.split('.')[-1].capitalize(), strict=True)
     if guild_check:

--- a/lyra/src/lib/queue.py
+++ b/lyra/src/lib/queue.py
@@ -8,8 +8,8 @@ import lavasnek_rs as lv
 
 from .utils import (
     ButtonBuilderType,
-    Contextish,
-    EitherContext,
+    ContextishType,
+    AnyContextType,
     edit_components,
     err_say,
     get_rest,
@@ -19,7 +19,7 @@ from .utils import (
 from .consts import ADD_TRACKS_WRAP_LIM
 from .extras import (
     NULL,
-    MaybeIterable,
+    IterableOr,
     Option,
     Result,
     Panic,
@@ -55,7 +55,7 @@ logger.setLevel(logging.DEBUG)
 
 
 async def to_tracks(
-    ctx: EitherContext,
+    ctx: tj.abc.Context,
     lvc: lv.Lavalink,
     /,
     value: str,
@@ -67,7 +67,7 @@ async def to_tracks(
     tracks: list[Trackish] = []
     errors: list[ValueError] = []
     songs = (*map(lambda s: s.strip("<>|"), value.split(' | ')),)
-    async with trigger_thinking(ctx):
+    async with trigger_thinking(t.cast(AnyContextType, ctx)):
         for song in songs:
             query = (
                 song if url_regex.fullmatch(song) else '%ssearch:%s' % (source, song)
@@ -89,7 +89,7 @@ async def play(
     ctx: tj.abc.Context,
     lvc: lv.Lavalink,
     /,
-    tracks: MaybeIterable[Trackish],
+    tracks: IterableOr[Trackish],
     *,
     respond: bool = False,
     shuffle: bool = False,
@@ -110,7 +110,7 @@ async def add_tracks_(
     ctx: tj.abc.Context,
     lvc: lv.Lavalink,
     /,
-    tracks_: MaybeIterable[Trackish],
+    tracks_: IterableOr[Trackish],
     queue: QueueList,
     *,
     respond: bool = False,
@@ -273,7 +273,7 @@ async def remove_tracks(
     return rm
 
 
-async def shuffle_abs(ctx_: Contextish, lvc: lv.Lavalink):
+async def shuffle_abs(ctx_: ContextishType, lvc: lv.Lavalink):
     async with access_queue(ctx_, lvc) as q:
         if not q.upcoming:
             await err_say(ctx_, content=f"❗ This is the end of the queue")
@@ -332,7 +332,7 @@ async def insert_track(
 
 
 async def repeat_abs(
-    ctx_: Contextish,
+    ctx_: ContextishType,
     mode: Option[RepeatMode],
     lvc: lv.Lavalink,
 ) -> Panic[None]:

--- a/lyra/src/lib/utils/types.py
+++ b/lyra/src/lib/utils/types.py
@@ -6,34 +6,27 @@ import tanjun as tj
 from ..extras.types import Coro
 
 
-EitherContext = tj.abc.MessageContext | tj.abc.AppCommandContext
-Contextish = tj.abc.Context | hk.ComponentInteraction
+AnyContextType = tj.abc.MessageContext | tj.abc.AppCommandContext
+ContextishType = tj.abc.Context | hk.ComponentInteraction
 """A union "Context-ish" type hint. Includes:
 * `tanjun.abc.Context` - A proper Context data
 * `hikari.ComponentInteraction` - A similarly structured data"""
 
-GuildInferableEvents = hk.GuildEvent | hk.VoiceEvent
-"""A union type hint of events that can infer its guild id. Includes:
+GuildAwareEventType = hk.GuildEvent | hk.VoiceEvent
+"""A union type hint of events that can infer its guild id. Includes
 * `hikari.GuildEvent`
 * `hikari.VoiceEvent`"""
 
-GuildOrInferable = Contextish | hk.Snowflakeish | GuildInferableEvents
+GuildOrAwareType = ContextishType | hk.Snowflakeish | GuildAwareEventType
 """A union type hint of objects that can infer its guild id, or is the id itself. Includes:
 * `hikari.Snowflakeish`
 * `Contextish`
 * `GuildInferableEvents`"""
 
-RESTInferable = Contextish | GuildInferableEvents
+RESTAwareType = ContextishType | GuildAwareEventType
 """A union type hint of objects that can infer its `hikari.api.RESTClient` client. Includes:
 * `Contextish`
 * `GuildInferableEvents`"""
-
-GuildOrRESTInferable = GuildOrInferable | RESTInferable
-"""A union type hint of objects that can infer its `hikari.api.RESTClient` client, its guild id, or is the id itself. Includes:
-* `GuildOrInferable`
-* `RESTInferable`"""
-
-MaybeClientInferable = t.Any | tj.abc.Context
 
 ButtonBuilderType = hk.api.ButtonBuilder[hk.api.ActionRowBuilder]
 ConnectionInfo = dict[
@@ -47,4 +40,62 @@ JoinableChannelType = hk.GuildVoiceChannel | hk.GuildStageChannel
 
 BindSig = t.Callable[..., Coro[bool]] | t.Callable[..., bool]
 
-with_annotated_args = tj.annotations.with_annotated_args(follow_wrapped=True)
+with_annotated_args_wrapped = tj.annotations.with_annotated_args(follow_wrapped=True)
+
+
+@t.runtime_checkable
+class MaybeGuildIDAware(t.Protocol):
+    @property
+    def guild_id(self) -> t.Optional[int]:
+        ...
+
+
+@t.runtime_checkable
+class ChannelAware(t.Protocol):
+    @property
+    def channel_id(self) -> int:
+        ...
+
+    async def fetch_channel(self) -> hk.TextableChannel:
+        ...
+
+
+@t.runtime_checkable
+class ClientAware(t.Protocol):
+    @property
+    def client(self) -> tj.abc.Client:
+        ...
+
+
+class Contextish(ChannelAware, t.Protocol):
+    ...
+
+
+@t.runtime_checkable
+class RESTAware(t.Protocol):
+    @property
+    def rest(self) -> hk.api.RESTClient:
+        ...
+
+
+@t.runtime_checkable
+class RESTAwareAware(t.Protocol):
+    @property
+    def app(self) -> hk.RESTAware:
+        ...
+
+
+class GuildContextish(Contextish, MaybeGuildIDAware, t.Protocol):
+    @property
+    def member(self) -> t.Optional[hk.Member]:
+        ...
+
+
+class ClientAwareGuildContextish(GuildContextish, ClientAware, t.Protocol):
+    ...
+
+
+@t.runtime_checkable
+class IntCastable(t.Protocol):
+    def __int__(self) -> int:
+        ...

--- a/lyra/src/modules/config.py
+++ b/lyra/src/modules/config.py
@@ -29,7 +29,7 @@ from ..lib.utils import (
     RESTRICTOR,
     MentionableType,
     PartialMentionableType,
-    with_annotated_args,
+    with_annotated_args_wrapped,
     with_message_command_group_template,
     say,
     err_say,
@@ -244,6 +244,15 @@ async def config_g_m(_: tj.abc.MessageContext):
 ## /config prefix
 
 
+@with_identifier(C.CONFIG_PREFIX)
+# -
+@config_g_m.as_sub_group('prefix', 'pfx', '/')
+@with_message_command_group_template
+async def prefix_sg_m(_: tj.abc.MessageContext):
+    """Manages the bot's prefixes"""
+    ...
+
+
 prefix_sg_s = with_identifier(C.CONFIG_PREFIX)(
     config_g_s.with_command(
         (tj.slash_command_group('prefix', "Manages the bot's prefixes"))
@@ -251,25 +260,13 @@ prefix_sg_s = with_identifier(C.CONFIG_PREFIX)(
 )
 
 
-@with_identifier(C.CONFIG_PREFIX)
-# -
-@config_g_m.with_command
-@tj.as_message_command_group('prefix', 'pfx', '/', strict=True)
-@with_message_command_group_template
-async def prefix_sg_m(_: tj.abc.MessageContext):
-    """Manages the bot's prefixes"""
-    ...
-
-
 ### /config prefix list
 
 
 @with_identifier(C.CONFIG_PREFIX_LIST)
 # -
-@prefix_sg_s.with_command
-@tj.as_slash_command('list', "Lists all usable prefixes of the bot")
-@prefix_sg_m.with_command
-@tj.as_message_command('list', 'l', '.')
+@prefix_sg_m.as_sub_command('list', 'l', '.')
+@prefix_sg_s.as_sub_command('list', "Lists all usable prefixes of the bot")
 async def prefix_list_(
     ctx: tj.abc.Context, cfg: al.Injected[LyraDBCollectionType]
 ) -> None:
@@ -296,13 +293,11 @@ async def prefix_list_(
 ### /config prefix add
 
 
-@with_annotated_args
+@with_annotated_args_wrapped
 @with_admin_cmd_check(C.CONFIG_PREFIX_ADD)
 # -
-@prefix_sg_s.with_command
-@tj.as_slash_command('add', "Adds a new prefix of the bot for this guild")
-@prefix_sg_m.with_command
-@tj.as_message_command('add', '+', 'a', 'new', 'create', 'n')
+@prefix_sg_m.as_sub_command('add', '+', 'a', 'new', 'create', 'n')
+@prefix_sg_s.as_sub_command('add', "Adds a new prefix of the bot for this guild")
 async def prefix_add_(
     ctx: tj.abc.Context,
     cfg: al.Injected[LyraDBCollectionType],
@@ -332,13 +327,13 @@ async def prefix_add_(
 ### /config prefix remove
 
 
-@with_annotated_args
+@with_annotated_args_wrapped
 @with_admin_cmd_check(C.CONFIG_PREFIX_REMOVE)
 # -
-@prefix_sg_s.with_command
-@tj.as_slash_command('remove', "Removes an existing prefix of the bot for this guild")
-@prefix_sg_m.with_command
-@tj.as_message_command('remove', '-', 'rem', 'r', 'rm', 'd', 'del', 'delete')
+@prefix_sg_m.as_sub_command('remove', '-', 'rem', 'r', 'rm', 'd', 'del', 'delete')
+@prefix_sg_s.as_sub_command(
+    'remove', "Removes an existing prefix of the bot for this guild"
+)
 async def prefix_remove_(
     ctx: tj.abc.Context,
     cfg: al.Injected[LyraDBCollectionType],
@@ -370,15 +365,6 @@ async def prefix_remove_(
 ## /config nowplayingmsg
 
 
-nowplayingmsg_sg_s = with_identifier(C.CONFIG_NOWPLAYINGMSG)(
-    config_g_s.with_command(
-        tj.slash_command_group(
-            'now-playing-msg', "Manages the bot's now playing messages"
-        )
-    )
-)
-
-
 @with_identifier(C.CONFIG_NOWPLAYINGMSG)
 # -
 @config_g_m.with_command
@@ -391,17 +377,24 @@ async def nowplayingmsg_sg_m(_: tj.abc.MessageContext):
     ...
 
 
+nowplayingmsg_sg_s = with_identifier(C.CONFIG_NOWPLAYINGMSG)(
+    config_g_s.with_command(
+        tj.slash_command_group(
+            'now-playing-msg', "Manages the bot's now playing messages"
+        )
+    )
+)
+
+
 ### /config nowplayingmsg toggle
 
 
 @with_author_permission_check(hkperms.MANAGE_GUILD)(C.CONFIG_NOWPLAYINGMSG_TOGGLE)
 # -
-@nowplayingmsg_sg_s.with_command
-@tj.as_slash_command(
+@nowplayingmsg_sg_m.as_sub_command('toggle', 'tggl', 't')
+@nowplayingmsg_sg_s.as_sub_command(
     'toggle', "Toggles the now playing messages to be automatically sent or not"
 )
-@nowplayingmsg_sg_m.with_command
-@tj.as_message_command('toggle', 'tggl', 't')
 async def nowplayingmsg_toggle_(
     ctx: tj.abc.Context, cfg: al.Injected[LyraDBCollectionType]
 ):
@@ -428,15 +421,6 @@ async def nowplayingmsg_toggle_(
 ## /config restrict
 
 
-restrict_sg_s = with_identifier(C.CONFIG_RESTRICT)(
-    config_g_s.with_command(
-        tj.slash_command_group(
-            'restrict', "Manages the bot's restricted channels, roles and members"
-        )
-    )
-)
-
-
 @with_identifier(C.CONFIG_RESTRICT)
 # -
 @config_g_m.with_command
@@ -447,15 +431,24 @@ async def restrict_sg_m(_: tj.abc.MessageContext):
     ...
 
 
+restrict_sg_s = with_identifier(C.CONFIG_RESTRICT)(
+    config_g_s.with_command(
+        tj.slash_command_group(
+            'restrict', "Manages the bot's restricted channels, roles and members"
+        )
+    )
+)
+
+
 ### /config restrict list
 
 
 @with_identifier(C.CONFIG_RESTRICT_LIST)
 # -
-@restrict_sg_s.with_command
-@tj.as_slash_command('list', "Shows the current restricted channels, roles and members")
-@restrict_sg_m.with_command
-@tj.as_message_command('list', 'ls', 'l', '.', 'all', '/')
+@restrict_sg_m.as_sub_command('list', 'ls', 'l', '.', 'all', '/')
+@restrict_sg_s.as_sub_command(
+    'list', "Shows the current restricted channels, roles and members"
+)
 async def restrict_list_(ctx: tj.abc.Context, cfg: al.Injected[LyraDBCollectionType]):
     """Shows the current restricted channels, roles and members"""
 
@@ -498,15 +491,13 @@ async def restrict_list_(ctx: tj.abc.Context, cfg: al.Injected[LyraDBCollectionT
 ### /config restrict add
 
 
-@with_annotated_args
+@with_annotated_args_wrapped
 @with_restricts_cmd_check(C.CONFIG_RESTRICT_ADD)
 # -
-@restrict_sg_s.with_command
-@tj.as_slash_command(
+@restrict_sg_m.as_sub_command('add', 'a', '+')
+@restrict_sg_s.as_sub_command(
     'add', "Adds new channels, roles or members to the restricted list"
 )
-@restrict_sg_m.with_command
-@tj.as_message_command('add', 'a', '+')
 # TODO: Remove tyoe casting when tanjun relaxed converter func sig
 async def restrict_add_(
     ctx: tj.abc.MessageContext,
@@ -536,15 +527,13 @@ async def restrict_add_(
 ### /config restrict remove
 
 
-@with_annotated_args
+@with_annotated_args_wrapped
 @with_restricts_cmd_check(C.CONFIG_RESTRICT_REMOVE)
 # -
-@restrict_sg_s.with_command
-@tj.as_slash_command(
+@restrict_sg_m.as_sub_command('remove', 'rm', 'del', 'r', 'd', '-')
+@restrict_sg_s.as_sub_command(
     'remove', "Removes existing channels, roles or members from the restricted list"
 )
-@restrict_sg_m.with_command
-@tj.as_message_command('remove', 'rm', 'del', 'r', 'd', '-')
 # TODO: Remove type casting when tanjun relaxed converter func sig
 async def restrict_remove_(
     ctx: tj.abc.MessageContext,
@@ -574,13 +563,13 @@ async def restrict_remove_(
 ### /config restrict blacklist
 
 
-@with_annotated_args
+@with_annotated_args_wrapped
 @with_restricts_cmd_check(C.CONFIG_RESTRICT_BLACKLIST)
 # -
-@restrict_sg_s.with_command
-@tj.as_slash_command('blacklist', "Sets a category's restriction mode to blacklisting")
-@restrict_sg_m.with_command
-@tj.as_message_command('blacklist', 'bl')
+@restrict_sg_m.as_sub_command('blacklist', 'bl')
+@restrict_sg_s.as_sub_command(
+    'blacklist', "Sets a category's restriction mode to blacklisting"
+)
 async def restrict_blacklist_(
     ctx: tj.abc.Context,
     cfg: al.Injected[LyraDBCollectionType],
@@ -598,13 +587,13 @@ async def restrict_blacklist_(
 ### /config restrict whitelist
 
 
-@with_annotated_args
+@with_annotated_args_wrapped
 @with_restricts_cmd_check(C.CONFIG_RESTRICT_WHITELIST)
 # -
-@restrict_sg_s.with_command
-@tj.as_slash_command('whitelist', "Sets a category's restriction mode to whitelisting")
-@restrict_sg_m.with_command
-@tj.as_message_command('whitelist', 'wl')
+@restrict_sg_m.as_sub_command('whitelist', 'wl')
+@restrict_sg_s.as_sub_command(
+    'whitelist', "Sets a category's restriction mode to whitelisting"
+)
 async def restrict_whitelist_(
     ctx: tj.abc.Context,
     cfg: al.Injected[LyraDBCollectionType],
@@ -622,13 +611,11 @@ async def restrict_whitelist_(
 ### /config restrict clear
 
 
-@with_annotated_args
+@with_annotated_args_wrapped
 @with_restricts_cmd_check(C.CONFIG_RESTRICT_CLEAR)
 # -
-@restrict_sg_s.with_command
-@tj.as_slash_command('clear', "Clears a category's restriction mode")
-@restrict_sg_m.with_command
-@tj.as_message_command('clear', 'clr')
+@restrict_sg_m.as_sub_command('clear', 'clr')
+@restrict_sg_s.as_sub_command('clear', "Clears a category's restriction mode")
 async def restrict_clear_(
     ctx: tj.abc.Context,
     cfg: al.Injected[LyraDBCollectionType],
@@ -653,10 +640,8 @@ async def restrict_clear_(
 
 @with_dangerous_restricts_cmd_check(C.CONFIG_RESTRICT_WIPE)
 # -
-@restrict_sg_s.with_command
-@tj.as_slash_command('wipe', "Wipes the restricted list of EVERY category")
-@restrict_sg_m.with_command
-@tj.as_message_command('wipe', 'reset', 'wp')
+@restrict_sg_m.as_sub_command('wipe', 'reset', 'wp')
+@restrict_sg_s.as_sub_command('wipe', "Wipes the restricted list of EVERY category")
 async def restrict_wipe_(ctx: tj.abc.Context, cfg: al.Injected[LyraDBCollectionType]):
     """Wipes the restricted list of EVERY category"""
 

--- a/lyra/src/modules/connections.py
+++ b/lyra/src/modules/connections.py
@@ -159,7 +159,7 @@ async def on_voice_state_update(
 # /join
 
 
-# TODO: Use annotation-based option declaration once declaring positional-only argument is possible
+# TODO: Use tanjun's new annotation system and combine message & slash options once possible
 @with_identifier(C.JOIN)
 # -
 @tj.with_channel_slash_option(

--- a/lyra/src/modules/debug.py
+++ b/lyra/src/modules/debug.py
@@ -17,7 +17,7 @@ from ..lib.extras import lgfmt
 from ..lib.utils import (
     say,
     err_say,
-    with_annotated_args,
+    with_annotated_args_wrapped,
     with_message_command_group_template,
 )
 
@@ -45,11 +45,6 @@ modules_tup = (*modules,)
 # /debug
 
 
-debug_g_s = with_identifier(C.DEBUG)(
-    tj.slash_command_group('debug', "For debugging purposes only")
-)
-
-
 @with_identifier(C.DEBUG)
 # -
 @tj.as_message_command_group(
@@ -65,20 +60,17 @@ async def debug_g_m(_: tj.abc.MessageContext):
     ...
 
 
-## /debug module
-
-
-module_sg_s = with_identifier(C.DEBUG_MODULE)(
-    debug_g_s.with_command(
-        tj.slash_command_group('module', "Manages the bot's modules")
-    )
+debug_g_s = with_identifier(C.DEBUG)(
+    tj.slash_command_group('debug', "For debugging purposes only")
 )
+
+
+## /debug module
 
 
 @with_identifier(C.DEBUG_MODULE)
 # -
-@debug_g_m.with_command
-@tj.as_message_command_group(
+@debug_g_m.as_sub_group(
     'module',
     'modules',
     'm',
@@ -92,16 +84,21 @@ async def module_sg_m(_: tj.abc.MessageContext):
     ...
 
 
+module_sg_s = with_identifier(C.DEBUG_MODULE)(
+    debug_g_s.with_command(
+        tj.slash_command_group('module', "Manages the bot's modules")
+    )
+)
+
+
 ### /debug module reload
 
 
-@with_annotated_args
+@with_annotated_args_wrapped
 @with_identifier(C.DEBUG_MODULE_RELOAD)
 # -
-@module_sg_s.with_command
-@tj.as_slash_command('reload', "Reloads a module")
-@module_sg_m.with_command
-@tj.as_message_command('reload', 'rl')
+@module_sg_m.as_sub_command('reload', 'rl')
+@module_sg_s.as_sub_command('reload', "Reloads a module")
 async def reload_module(
     ctx: tj.abc.Context,
     module: t.Annotated[ja.Str, "Which module?", ja.Choices(modules_tup)],
@@ -120,13 +117,11 @@ async def reload_module(
 ### /debug module unload
 
 
-@with_annotated_args
+@with_annotated_args_wrapped
 @with_identifier(C.DEBUG_MODULE_UNLOAD)
 # -
-@module_sg_s.with_command
-@tj.as_slash_command('unload', "Unloads a module")
-@module_sg_m.with_command
-@tj.as_message_command('unload', 'ul')
+@module_sg_m.as_sub_command('unload', 'ul')
+@module_sg_s.as_sub_command('unload', "Unloads a module")
 async def unload_module(
     ctx: tj.abc.Context,
     module: t.Annotated[ja.Str, "Which module?", ja.Choices(modules_tup)],
@@ -146,13 +141,11 @@ async def unload_module(
 ### /debug module load
 
 
-@with_annotated_args
+@with_annotated_args_wrapped
 @with_identifier(C.DEBUG_MODULE_LOAD)
 # -
-@module_sg_s.with_command
-@tj.as_slash_command('load', "Loads a module")
-@module_sg_m.with_command
-@tj.as_message_command('load', 'lo')
+@module_sg_m.as_sub_command('load', 'lo')
+@module_sg_s.as_sub_command('load', "Loads a module")
 async def load_module(
     ctx: tj.abc.Context,
     module: t.Annotated[ja.Str, "Which module?", ja.Choices(modules_tup)],
@@ -172,13 +165,6 @@ async def load_module(
 ## /debug command
 
 
-command_sg_s = with_identifier(C.DEBUG_COMMAND)(
-    debug_g_s.with_command(
-        tj.slash_command_group('command', "Manages the bot's commands")
-    )
-)
-
-
 @with_identifier(C.DEBUG_COMMAND)
 # -
 @debug_g_m.with_command
@@ -195,15 +181,20 @@ async def command_sg_m(_: tj.abc.MessageContext):
     ...
 
 
+command_sg_s = with_identifier(C.DEBUG_COMMAND)(
+    debug_g_s.with_command(
+        tj.slash_command_group('command', "Manages the bot's commands")
+    )
+)
+
+
 ### /debug command delete-all
 
 
 @with_identifier(C.DEBUG_COMMAND_DELETEALL)
 # -
-@command_sg_s.with_command
-@tj.as_slash_command('delete-all', "Deletes all application commands")
-@command_sg_m.with_command
-@tj.as_message_command('delete-all', 'deleteall', 'delall', 'wipe', 'wp')
+@command_sg_m.as_sub_command('delete-all', 'deleteall', 'delall', 'wipe', 'wp')
+@command_sg_s.as_sub_command('delete-all', "Deletes all application commands")
 async def delete_all_app_commands(ctx: tj.abc.Context, bot: al.Injected[hk.GatewayBot]):
     """Deletes all global commands"""
 

--- a/lyra/src/modules/info.py
+++ b/lyra/src/modules/info.py
@@ -12,7 +12,7 @@ from ..lib.cmd.compose import with_identifier
 from ..lib.utils import (
     Q_CHUNK,
     TIMEOUT,
-    EitherContext,
+    AnyContextType,
     EmojiRefs,
     limit_img_size_by_guild,
     say,
@@ -20,7 +20,7 @@ from ..lib.utils import (
     extract_content,
     trigger_thinking,
     disable_components,
-    with_annotated_args,
+    with_annotated_args_wrapped,
 )
 from ..lib.music import stop, unstop
 from ..lib.musicutils import generate_queue_embeds, __init_component__
@@ -117,7 +117,7 @@ with_se_cmd_check_and_connect_vc = with_cmd_composer(
 )
 
 
-@with_annotated_args
+@with_annotated_args_wrapped
 @with_se_cmd_check_and_connect_vc(C.SEARCH)
 # -
 @tj.as_message_command('search', 'se', 'f', 'yt', 'youtube')
@@ -126,7 +126,7 @@ with_se_cmd_check_and_connect_vc = with_cmd_composer(
     "Searches for tracks on youtube from your query and lets you hear a part of it",
 )
 async def search_(
-    ctx: EitherContext,
+    ctx: tj.abc.Context,
     lvc: al.Injected[lv.Lavalink],
     query: t.Annotated[ja.Greedy[ja.Str], "What to be queried?"],
 ):
@@ -148,7 +148,7 @@ async def search_c(
     await _search(ctx, cnt, lvc)
 
 
-async def _search(ctx: EitherContext, query: str, lvc: lv.Lavalink) -> Result[None]:
+async def _search(ctx: tj.abc.Context, query: str, lvc: lv.Lavalink) -> Result[None]:
     from ..lib.music import play, add_tracks_
 
     erf = ctx.client.get_type_dependency(EmojiRefs)
@@ -163,7 +163,7 @@ async def _search(ctx: EitherContext, query: str, lvc: lv.Lavalink) -> Result[No
     bot = ctx.client.get_type_dependency(hk.GatewayBot)
     assert not isinstance(bot, al.abc.Undefined)
 
-    async with trigger_thinking(ctx):
+    async with trigger_thinking(t.cast(AnyContextType, ctx)):
         results = await lvc.auto_search_tracks(query)
     if results.load_type in {'TRACK_LOADED', 'PLAYLIST_LOADED'}:
         play_r = get_full_cmd_repr_from_identifier(C.PLAY, ctx)
@@ -465,13 +465,13 @@ async def queue_(
 # /lyrics
 
 
-@with_annotated_args
+@with_annotated_args_wrapped
 @with_identifier(C.LYRICS)
 # -
 @tj.as_slash_command('lyrics', 'Attempts to find the lyrics of the current song')
 @tj.as_message_command('lyrics', 'ly')
 async def lyrics_(
-    ctx: EitherContext,
+    ctx: tj.abc.Context,
     lvc: al.Injected[lv.Lavalink],
     song: t.Annotated[
         Option[ja.Greedy[ja.Str]], "What song? (If not given, the current song)"
@@ -507,7 +507,7 @@ async def lyrics_(
     )
 
     try:
-        async with trigger_thinking(ctx):
+        async with trigger_thinking(t.cast(AnyContextType, ctx)):
             lyrics = await get_lyrics(song)
     except LyricsNotFound:
         await err_say(ctx, content=f"❓ Could not find any lyrics for the song")

--- a/lyra/src/modules/playback.py
+++ b/lyra/src/modules/playback.py
@@ -43,7 +43,7 @@ from ..lib.utils import (
     ConnectionInfo,
     say,
     err_say,
-    with_annotated_args,
+    with_annotated_args_wrapped,
 )
 
 
@@ -241,21 +241,20 @@ async def stop_(
 # /fast-forward
 
 
-# TODO: Use annotation-based option declaration once declaring positional-only argument is possible
+@with_annotated_args_wrapped
 @with_activity_cmd_check(C.FASTFORWARD)
 # -
-@tj.with_float_slash_option(
-    'seconds', "Fast-foward by how much? (If not given, 10 seconds)", default=10.0
-)
 @tj.as_slash_command('fast-forward', "Fast-forwards the current track")
-@tj.with_argument('seconds', converters=float, default=10.0)
 @tj.as_message_command(
     'fast-forward', 'fastforward', 'forward', 'fw', 'fwd', 'ff', '>>'
 )
 async def fastforward_(
     ctx: tj.abc.MessageContext,
     lvc: al.Injected[lv.Lavalink],
-    seconds: float,
+    seconds: t.Annotated[
+        ja.Positional[ja.Float],
+        "Fast-foward by how much? (If not given, 10 seconds)",
+    ] = 10.0,
 ):
     async with access_queue(ctx, lvc) as q:
         assert not ((q.current is None) or (q.np_position is None))
@@ -281,19 +280,17 @@ async def fastforward_(
 # /rewind
 
 
-# TODO: Use annotation-based option declaration once declaring positional-only argument is possible
+@with_annotated_args_wrapped
 @with_activity_cmd_check(C.REWIND)
 # -
-@tj.with_float_slash_option(
-    'seconds', "Rewind by how much? (If not given, 10 seconds)", default=10.0
-)
 @tj.as_slash_command('rewind', "Rewinds the current track")
-@tj.with_argument('seconds', converters=float, default=10.00)
 @tj.as_message_command('rewind', 'rw', 'rew', '<<')
 async def rewind_(
     ctx: tj.abc.Context,
     lvc: al.Injected[lv.Lavalink],
-    seconds: float,
+    seconds: t.Annotated[
+        ja.Positional[ja.Float], "Rewind by how much? (If not given, 10 seconds)"
+    ] = 10.0,
 ):
     async with access_queue(ctx, lvc) as q:
         assert not ((q.current is None) or (q.np_position is None))
@@ -343,7 +340,7 @@ with_playat_cmd_check_and_voting = with_cmd_composer(
 )
 
 
-@with_annotated_args
+@with_annotated_args_wrapped
 @with_playat_cmd_check_and_voting(C.PLAYAT)
 # -
 @tj.as_slash_command("play-at", "Plays the track at the specified position")
@@ -450,7 +447,7 @@ async def restart_(ctx: tj.abc.Context, lvc: al.Injected[lv.Lavalink]):
 # /seek
 
 
-@with_annotated_args
+@with_annotated_args_wrapped
 @with_activity_cmd_check(C.SEEK)
 # -
 @tj.as_slash_command("seek", "Seeks the current track to a timestamp")

--- a/lyra/src/modules/tuning.py
+++ b/lyra/src/modules/tuning.py
@@ -18,7 +18,7 @@ from ..lib.extras import Option, Panic
 from ..lib.utils import (
     say,
     err_say,
-    with_annotated_args,
+    with_annotated_args_wrapped,
     with_message_command_group_template,
 )
 from ..lib.errors import NotConnected
@@ -96,11 +96,7 @@ async def on_voice_state_update(
 # /volume
 
 
-volume_g_s = with_identifier(C.VOLUME)(
-    tj.slash_command_group('volume', "Manages the volume of this guild's player")
-)
-
-
+@with_annotated_args_wrapped
 @with_identifier(C.VOLUME)
 # -
 @tj.as_message_command_group('volume', 'v', 'vol', strict=True)
@@ -110,16 +106,19 @@ async def volume_g_m(_: tj.abc.MessageContext):
     ...
 
 
+volume_g_s = with_identifier(C.VOLUME)(
+    tj.slash_command_group('volume', "Manages the volume of this guild's player")
+)
+
+
 ## /volume set
 
 
-@with_annotated_args
+@with_annotated_args_wrapped
 @with_stage_cmd_check(C.VOLUME_SET)
 # -
-@volume_g_s.with_command
-@tj.as_slash_command('set', "Set the volume of the bot from 0-10")
-@volume_g_m.with_command
-@tj.as_message_command('set', '=', '.')
+@volume_g_m.as_sub_command('set', '=', '.')
+@volume_g_s.as_sub_command('set', "Set the volume of the bot from 0-10")
 async def volume_set_(
     ctx: tj.abc.Context,
     lvc: al.Injected[lv.Lavalink],
@@ -142,22 +141,17 @@ async def volume_set_(
 ## /volume up
 
 
-# TODO: Use annotation-based option declaration once declaring positional-only argument is possible
+@with_annotated_args_wrapped
 @with_stage_cmd_check(C.VOLUME_UP)
 # -
-@volume_g_s.with_command
-@tj.with_int_slash_option(
-    'amount', "Increase by how much (If not given, by 1)", default=1
-)
-@tj.as_slash_command('up', "Increase the bot's volume")
-#
-@volume_g_m.with_command
-@tj.with_argument('amount', converters=int, default=1)
-@tj.as_message_command('up', 'u', '+', '^')
+@volume_g_m.as_sub_command('up', 'u', '+', '^')
+@volume_g_s.as_sub_command('up', "Increase the bot's volume")
 async def volume_up_(
     ctx: tj.abc.Context,
     lvc: al.Injected[lv.Lavalink],
-    amount: int,
+    amount: t.Annotated[
+        ja.Positional[ja.Int], "Increase by how much (If not given, by 1)"
+    ] = 1,
 ):
     """
     Increase the bot's volume
@@ -185,22 +179,17 @@ async def volume_up_(
 ## /volume down
 
 
-# TODO: Use annotation-based option declaration once declaring positional-only argument is possible
+@with_annotated_args_wrapped
 @with_stage_cmd_check(C.VOLUME_DOWN)
 # -
-@volume_g_s.with_command
-@tj.with_int_slash_option(
-    'amount', "Decrease by how much? (If not given, by 1)", default=1
-)
-@tj.as_slash_command('down', "Decrease the bot's volume")
-#
-@volume_g_m.with_command
-@tj.with_argument('amount', converters=int, default=1)
-@tj.as_message_command('down', 'd', '-', 'v')
+@volume_g_m.as_sub_command('down', 'd', '-', 'v')
+@volume_g_s.as_sub_command('down', "Decrease the bot's volume")
 async def volume_down_(
     ctx: tj.abc.Context,
     lvc: al.Injected[lv.Lavalink],
-    amount: int,
+    amount: t.Annotated[
+        ja.Positional[ja.Int], "Decrease by how much? (If not given, by 1)"
+    ] = 1,
 ):
     """
     Decrease the bot's volume"
@@ -270,11 +259,6 @@ async def mute_unmute_(ctx: tj.abc.Context, lvc: al.Injected[lv.Lavalink]):
 # /equalizer
 
 
-equalizer_g_s = with_identifier(C.EQUALIZER)(
-    tj.slash_command_group('equalizer', "Manages the bot's equalizer")
-)
-
-
 @with_identifier(C.EQUALIZER)
 # -
 @tj.as_message_command_group('equalizer', 'eq', strict=True)
@@ -282,6 +266,11 @@ equalizer_g_s = with_identifier(C.EQUALIZER)(
 async def equalizer_g_m(_: tj.abc.MessageContext):
     """Manages the bot's equalizer"""
     ...
+
+
+equalizer_g_s = with_identifier(C.EQUALIZER)(
+    tj.slash_command_group('equalizer', "Manages the bot's equalizer")
+)
 
 
 ## /equalizer preset
@@ -296,13 +285,11 @@ valid_presets: t.Final[dict[str, str]] = t.cast(
 ) | {'Flat': 'flat'}
 
 
-@with_annotated_args
+@with_annotated_args_wrapped
 @with_stage_cmd_check(C.EQUALIZER_PRESET)
 # -
-@equalizer_g_s.with_command
-@tj.as_slash_command('preset', "Sets the bot's equalizer to a preset")
-@equalizer_g_m.with_command
-@tj.as_message_command('preset', 'pre', '=')
+@equalizer_g_m.as_sub_command('preset', 'pre', '=')
+@equalizer_g_s.as_sub_command('preset', "Sets the bot's equalizer to a preset")
 async def equalizer_preset_(
     ctx: tj.abc.Context,
     lvc: al.Injected[lv.Lavalink],


### PR DESCRIPTION
`?` `MaybeIterable` -> `IterableOr`
`+` `AnyOr`
`*` Changed Typing around util funcs
 | `*` `EitherContext` -> `AnyContextType`
 | `*` `Contextish` -> `ContextishType`
 | `*` `GuildInferableEvents` -> `GuildAwareEventType`
 | `*` `GuildOrInferable` -> `GuildOrAwareType`
 | `*` `RestInferable` -> `RESTAwareType`
 | `-` `GuildOrRESTInferable`
 | `-` `MaybeClientInferable` (replaced with `AnyOr[ClientAware]`
 | `*` `with_annotated_args(...)` -> `with_annotated_args_wrapped(...)`
 | `+` `MaybeGuildIDAware`
 | `+` `ChannelAware`
 | `+` `ClientAware`
 | `+` `Contextish`
 | `+` `RESTAware`
 | `+` `RESTAwareAware`
 | `+` `GuildContextish`
 | `+` `ClientAwareGuildContextish`
 | `+` `IntCastable`
 | `*` Reduced the use of `AnyContextType`
`*` Every message cmds declaration will now be put above slash cmds
`*` Updated `hikari-tanjun` to `2.7.0a1`
 | `*` Massively reduced boilerplate in group cmds /w `.as_sub_command(...)` decorator
 | `*` Made every to-do'd command use tanjun's annotation declaration system