### PR TITLE
Fix overlapped reponses from `/fast-forward` & `/rewind`

### DIFF
--- a/lyra/src/lib/queue.py
+++ b/lyra/src/lib/queue.py
@@ -351,11 +351,9 @@ async def repeat_abs(
     elif mode is RepeatMode.ALL:
         msg = "Repeating the entire queue"
         e = '🔁'
-    elif mode is RepeatMode.ONE:
+    else:
         msg = "Repeating only this current track"
         e = '🔂'
-    else:
-        raise NotImplementedError
 
     from .lava.utils import get_repeat_emoji
 

--- a/lyra/src/modules/playback.py
+++ b/lyra/src/modules/playback.py
@@ -270,6 +270,7 @@ async def fastforward_(
                 ctx,
                 content=f"❕⏭️ ~~`{np_info.title}`~~ *(The fast-forwarded time was too large; **Skipping** to the next track)*",
             )
+            return
         fmt_sec = f"{I if (I := int(seconds)) == seconds else f'{seconds:.3f}'}s"
         await say(
             ctx,
@@ -305,6 +306,7 @@ async def rewind_(
                 ctx,
                 content=f"❕◀️ *The rewinded time was too large; **Restarted** the current track*",
             )
+            return
         fmt_sec = f"{I if (I := int(seconds)) == seconds else f'{seconds:.3f}'}s"
         await say(
             ctx,
@@ -469,11 +471,11 @@ async def seek_(
                 ctx,
                 content=f"❌ Invalid timestamp position given; The track's length is `{to_stamp(xe.arg.expected)}` but was given `{to_stamp(xe.arg.got)}`",
             )
-        else:
-            await say(
-                ctx,
-                content=f"🕹️ ~~`{to_stamp(old_np_ms)}`~~ ➜ **`{to_stamp(timestamp)}`**",
-            )
+            return
+        await say(
+            ctx,
+            content=f"🕹️ ~~`{to_stamp(old_np_ms)}`~~ ➜ **`{to_stamp(timestamp)}`**",
+        )
 
 
 # -

--- a/lyra/src/modules/queue.py
+++ b/lyra/src/modules/queue.py
@@ -258,16 +258,15 @@ async def remove_one_(
             ctx,
             content=f"❌ Please specify a track to remove or have a track playing first",
         )
+        return
     except IllegalArgument as xe:
         arg_exp = xe.arg.expected
         await err_say(
             ctx,
             content=f"❌ Invalid position. **The track position must be between `{arg_exp[0]}` and `{arg_exp[1]}`**",
         )
-    else:
-        await say(
-            ctx, content=f"**`ー`** Removed `{rm.track.info.title}` from the queue"
-        )
+        return
+    await say(ctx, content=f"**`ー`** Removed `{rm.track.info.title}` from the queue")
 
 
 ## /remove bulk
@@ -305,20 +304,20 @@ async def remove_bulk_(
             delete_after=6.5,
             content=f"❌ Invalid start position or end position\n**Start position must be smaller or equal to end position *AND* both of them has to be in between 1 and the queue length **",
         )
-    else:
+        return
+    await say(
+        ctx,
+        content=f"**`≡⁻`** Removed track position `{start}-{end}` `({t_n} tracks)` from the queue",
+    )
+    if start == 1 and end == q_l:
+        remove_bulk_r = get_full_cmd_repr_from_identifier(C.REMOVE_BULK, ctx)
+        clear_r = get_full_cmd_repr_from_identifier(C.CLEAR, ctx)
         await say(
             ctx,
-            content=f"**`≡⁻`** Removed track position `{start}-{end}` `({t_n} tracks)` from the queue",
+            hidden=True,
+            follow_up=True,
+            content=f"💡 It is best to only remove a part of the queue when using {remove_bulk_r}. *For clearing the entire queue, use {clear_r} instead*",
         )
-        if start == 1 and end == q_l:
-            remove_bulk_r = get_full_cmd_repr_from_identifier(C.REMOVE_BULK, ctx)
-            clear_r = get_full_cmd_repr_from_identifier(C.CLEAR, ctx)
-            await say(
-                ctx,
-                hidden=True,
-                follow_up=True,
-                content=f"💡 It is best to only remove a part of the queue when using {remove_bulk_r}. *For clearing the entire queue, use {clear_r} instead*",
-            )
 
 
 # /clear
@@ -397,23 +396,20 @@ async def move_last_(
             content=f"❌ Please specify a track to move or have a track playing first",
         )
         return
-
     except IllegalArgument:
         await err_say(
             ctx,
             content=f"❌ Invalid position. **The track position must be between `1` and `{len(q)}`**",
         )
         return
-
     except ValueError:
         await err_say(ctx, content=f"❗ This track is already at the end of the queue")
         return
 
-    else:
-        await say(
-            ctx,
-            content=f"⏬ Moved track `{mv.track.info.title}` to the end of the queue",
-        )
+    await say(
+        ctx,
+        content=f"⏬ Moved track `{mv.track.info.title}` to the end of the queue",
+    )
 
 
 ## /move swap


### PR DESCRIPTION
Fixes #62
`*` some slight code refractoring