### PR TITLE
Improved aesthetics for `/queue`, `/search` & Error messages.

### DIFF
--- a/lyra/src/lib/cmd/compose.py
+++ b/lyra/src/lib/cmd/compose.py
@@ -26,7 +26,7 @@ from ..utils import (
     fetch_permissions,
     start_confirmation_prompt,
 )
-from ..extras import NULL, DecorateSig, ArgsDecorateSig, Option, Result, Panic
+from ..extras import NULL, DecorateSig, ArgsDecorateSig, Option, Fallible, Panic
 from ..errors import (
     AlreadyConnected,
     BaseLyraException,
@@ -48,7 +48,7 @@ from ..lava.utils import get_queue
 
 async def others_not_in_vc_check(
     ctx_: ContextishType, lvc: lv.Lavalink, /
-) -> Result[bool]:
+) -> Fallible[bool]:
     assert ctx_.guild_id
 
     conn = t.cast(

--- a/lyra/src/lib/connections.py
+++ b/lyra/src/lib/connections.py
@@ -20,7 +20,7 @@ from .utils import (
     get_client,
     say,
 )
-from .extras import Option, Result, lgfmt
+from .extras import Option, Fallible, lgfmt
 from .errors import (
     AlreadyConnected,
     ChannelMoved,
@@ -50,7 +50,7 @@ async def join(
     channel: Option[hk.GuildVoiceChannel | hk.GuildStageChannel],
     lvc: lv.Lavalink,
     /,
-) -> Result[hk.Snowflake]:
+) -> Fallible[hk.Snowflake]:
     """Joins your voice channel."""
     assert ctx.guild_id and ctx.member
 
@@ -160,7 +160,7 @@ async def join(
     return new_ch
 
 
-async def leave(ctx: tj.abc.Context, lvc: lv.Lavalink, /) -> Result[hk.Snowflakeish]:
+async def leave(ctx: tj.abc.Context, lvc: lv.Lavalink, /) -> Fallible[hk.Snowflakeish]:
     assert ctx.guild_id
 
     bot = ctx.client.get_type_dependency(hk.GatewayBot)
@@ -250,7 +250,7 @@ async def join_impl_precaught(
 
 async def others_not_in_vc_check_impl(
     ctx_: ContextishType, conn: ConnectionInfo, /, *, perms: hkperms = DJ_PERMS
-) -> Result[bool]:
+) -> Fallible[bool]:
     auth_perms = await fetch_permissions(ctx_)
     member = ctx_.member
     client = get_client(ctx_)

--- a/lyra/src/lib/consts.py
+++ b/lyra/src/lib/consts.py
@@ -6,7 +6,7 @@ LOG_PAD: t.Final = 16
 """Left aligned padding for each lib's logger name"""
 TIMEOUT: t.Final = 60
 """Base timeout time for buttons, drop-downs and command's wait for responses in seconds"""
-Q_CHUNK: t.Final = 15
+Q_CHUNK: t.Final = 10
 """Amount of tracks in the queue to be displayed per page in the `/queue` command"""
 RETRIES: t.Final = 3
 """Amount of tries to retry when some over-the-web operations failed"""

--- a/lyra/src/lib/errors/expects.py
+++ b/lyra/src/lib/errors/expects.py
@@ -28,7 +28,7 @@ from . import (
 from ..cmd import get_full_cmd_repr_from_identifier
 from ..cmd.ids import CommandIdentifier
 from ..utils import ContextishType, dj_perms_fmt, err_say, get_rest, say
-from ..extras import Result, format_flags
+from ..extras import Fallible, format_flags
 
 
 ExpectSig = t.Callable[[], t.Awaitable[None]]
@@ -39,7 +39,7 @@ class BaseErrorExpects(abc.ABC):
     context: ContextishType
 
     @abc.abstractmethod
-    def match_expect(self, error: Exception, /) -> Result[ExpectSig]:
+    def match_expect(self, error: Exception, /) -> Fallible[ExpectSig]:
         ...
 
     @abc.abstractmethod
@@ -149,7 +149,7 @@ class CheckErrorExpects(BaseErrorExpects):
     async def expect_not_developer(self):
         await err_say(self.context, content="🚫⚙️ Reserved for bot's developers only")
 
-    def match_expect(self, error: Exception, /) -> Result[ExpectSig]:
+    def match_expect(self, error: Exception, /) -> Fallible[ExpectSig]:
         match error:
             case lv.NetworkError():
                 return lambda: self.expect_network_error()
@@ -212,7 +212,7 @@ class BindErrorExpects(BaseErrorExpects):
             content=f"❌ Please join a voice channel first. You can also do {join_r} `channel:` `[🔊 ...]`",
         )
 
-    def match_expect(self, error: Exception, /) -> Result[ExpectSig]:
+    def match_expect(self, error: Exception, /) -> Fallible[ExpectSig]:
         match error:
             case NotInVoice():
                 return lambda: self.expect_not_in_voice()

--- a/lyra/src/lib/extras/types.py
+++ b/lyra/src/lib/extras/types.py
@@ -26,8 +26,8 @@ _KE = t.TypeVar('_KE')
 
 Coro = t.Coroutine[t.Any, t.Any, _T]
 Option = _T | None
-Result = t.Annotated[_T | t.NoReturn, ...]
-OptionResult = Option[Result[_T]]
+Fallible = t.Annotated[_T | t.NoReturn, ...]
+OptionFallible = Option[Fallible[_T]]
 Panic = t.Annotated[_T | t.NoReturn, ...]
 Require = t.Annotated[_T_co, ...]
 AnyOr = t.Any | _T

--- a/lyra/src/lib/extras/untyped.py
+++ b/lyra/src/lib/extras/untyped.py
@@ -17,7 +17,7 @@ import lavasnek_rs as lv
 
 from PIL import Image as pil_img
 
-from .types import Option, OptionResult, URLstr, RGBTriplet
+from .types import Option, OptionFallible, URLstr, RGBTriplet
 from .vars import (
     ytm_api,
     gn_api,
@@ -181,7 +181,7 @@ def get_img_pallete(
 
 
 @mz.cached
-def get_thumbnail(t_info: lv.Info, /) -> OptionResult[URLstr | bytes]:
+def get_thumbnail(t_info: lv.Info, /) -> OptionFallible[URLstr | bytes]:
     uri = t_info.uri
     id_ = t_info.identifier
 

--- a/lyra/src/lib/playback.py
+++ b/lyra/src/lib/playback.py
@@ -7,7 +7,7 @@ import alluka as al
 import lavasnek_rs as lv
 
 from .consts import TIMEOUT
-from .extras import Option, Result, Panic, MapSig, PredicateSig
+from .extras import Option, Fallible, Panic, MapSig, PredicateSig
 from .utils import (
     IntCastable,
     MaybeGuildIDAware,
@@ -37,7 +37,7 @@ from .lava.events import TrackStoppedEvent
 
 async def stop(g_: IntCastable | MaybeGuildIDAware, lvc: lv.Lavalink, /) -> None:
     async with access_queue(g_, lvc) as q:
-        if np_pos := q.np_position:
+        if np_pos := q.np_time:
             q.update_paused_np_position(np_pos)
         q.is_stopped = True
 
@@ -119,7 +119,7 @@ async def set_pause(
                 await err_say(g_r_, content="❗ Already resumed")
             return False
 
-        np_pos = q.np_position
+        np_pos = q.np_time
         if np_pos is None:
             raise NotPlaying
 
@@ -252,7 +252,9 @@ async def previous_abs(ctx_: ContextishType, lvc: lv.Lavalink):
     await say(ctx_, show_author=True, content=f"⏮️ **`{prev.track.info.title}`**")
 
 
-async def seek(ctx: tj.abc.Context, lvc: lv.Lavalink, total_ms: int, /) -> Result[int]:
+async def seek(
+    ctx: tj.abc.Context, lvc: lv.Lavalink, total_ms: int, /
+) -> Fallible[int]:
     assert ctx.guild_id
     if total_ms < 0:
         raise IllegalArgument(Argument(total_ms, 0))

--- a/lyra/src/lib/queue.py
+++ b/lyra/src/lib/queue.py
@@ -21,7 +21,7 @@ from .extras import (
     NULL,
     IterableOr,
     Option,
-    Result,
+    Fallible,
     Panic,
     url_regex,
     lgfmt,
@@ -116,7 +116,7 @@ async def add_tracks_(
     respond: bool = False,
     shuffle: bool = False,
     ignore_stop: bool = False,
-) -> Result[tuple[lv.Track, ...]]:
+) -> Fallible[tuple[lv.Track, ...]]:
     assert ctx.guild_id
     flttn_t: t.Iterable[lv.Track] = []
     if isinstance(tracks_, Trackish):
@@ -193,7 +193,7 @@ async def add_tracks_(
 
 async def remove_track(
     ctx: tj.abc.Context, track: Option[str], lvc: lv.Lavalink, /
-) -> Result[lv.TrackQueue]:
+) -> Fallible[lv.TrackQueue]:
     assert ctx.guild_id
 
     d = await get_data(ctx.guild_id, lvc)
@@ -243,7 +243,7 @@ async def remove_track(
 
 async def remove_tracks(
     ctx: tj.abc.Context, start: int, end: int, lvc: lv.Lavalink, /
-) -> Result[list[lv.TrackQueue]]:
+) -> Fallible[list[lv.TrackQueue]]:
     assert ctx.guild_id
 
     d = await get_data(ctx.guild_id, lvc)
@@ -289,7 +289,7 @@ async def shuffle_abs(ctx_: ContextishType, lvc: lv.Lavalink):
 
 async def insert_track(
     ctx: tj.abc.Context, insert: int, track: Option[int], lvc: lv.Lavalink, /
-) -> Result[lv.TrackQueue]:
+) -> Fallible[lv.TrackQueue]:
     assert ctx.guild_id
 
     d = await get_data(ctx.guild_id, lvc)

--- a/lyra/src/lib/utils/fmt.py
+++ b/lyra/src/lib/utils/fmt.py
@@ -1,0 +1,78 @@
+import enum as e
+import itertools as it
+
+from ..extras import Option, join_truthy, split_flags
+
+
+ANSI_BLOCK = "```ansi\n%s\n```"
+
+__format = "\u001b[%sm"
+__reset = "\u001b[0m"
+
+
+class Style(e.IntFlag):
+    _ = 0
+    """Normal"""
+    B = 1
+    """Bold"""
+    U = 4
+    """Underline"""
+
+
+class Fore(e.Enum):
+    D = 30
+    """Grey"""
+    R = 31
+    """Red"""
+    G = 32
+    """Green"""
+    Y = 33
+    """Yellow"""
+    B = 34
+    """Blue"""
+    M = 35
+    """Magenta"""
+    C = 36
+    """Cyan"""
+    W = 37
+    """White"""
+
+
+class Back(e.Enum):
+    B = 40
+    """Firefly Dark Blue"""
+    O = 41
+    """Orange"""
+    M = 42
+    """Marble Blue"""
+    T = 43
+    """Greyish Turquoise"""
+    G = 44
+    """Grey"""
+    I = 45
+    """Indigo"""
+    L = 46
+    """Light Grey"""
+    W = 47
+    """White"""
+
+
+def cl(
+    str_: str,
+    /,
+    style: Option[Style] = None,
+    back: Option[Back] = None,
+    fore: Option[Fore] = None,
+    *,
+    reset: bool = False,
+    block_fmt: bool = False,
+) -> str:
+    args = it.chain(
+        map(lambda f: str(f.value), split_flags(style) if style else {Style._}),
+        map(lambda f: str(f.value) if f else '', (back, fore)),
+    )
+    _fmt = join_truthy(args, ';')
+    formatted = f"{__format % _fmt}{str_}{__reset if reset else ''}"
+    if block_fmt:
+        return ANSI_BLOCK % formatted
+    return formatted

--- a/lyra/src/modules/config.py
+++ b/lyra/src/modules/config.py
@@ -34,6 +34,7 @@ from ..lib.utils import (
     say,
     err_say,
 )
+from ..lib.utils.fmt import ANSI_BLOCK, Fore, cl
 
 
 config = __init_component__(__name__)
@@ -284,7 +285,8 @@ async def prefix_list_(
     )
     embed.add_field(
         'Guild-specific',
-        '\n'.join('`%s`' % prf for prf in g_prefixes) or '```diff\n-Empty-\n```',
+        '\n'.join('`%s`' % prf for prf in g_prefixes)
+        or ANSI_BLOCK % cl("Empty", fore=Fore.D),
         inline=True,
     )
     await say(ctx, embed=embed)
@@ -465,7 +467,7 @@ async def restrict_list_(ctx: tj.abc.Context, cfg: al.Injected[LyraDBCollectionT
     u_wl: BlacklistMode = res_u.get('wl_mode', 0)
 
     def empty_or(str_: str):
-        return str_ or '```diff\n-Empty-\n```'
+        return str_ or ANSI_BLOCK % cl("Empty", fore=Fore.D)
 
     embed = (
         hk.Embed(

--- a/lyra/src/modules/playback.py
+++ b/lyra/src/modules/playback.py
@@ -257,9 +257,9 @@ async def fastforward_(
     ] = 10.0,
 ):
     async with access_queue(ctx, lvc) as q:
-        assert not ((q.current is None) or (q.np_position is None))
+        assert not ((q.current is None) or (q.np_time is None))
         np_info = q.current.track.info
-        old_np_ms = q.np_position
+        old_np_ms = q.np_time
         new_np_ms = old_np_ms + int(seconds * 1000)
 
         try:
@@ -294,8 +294,8 @@ async def rewind_(
     ] = 10.0,
 ):
     async with access_queue(ctx, lvc) as q:
-        assert not ((q.current is None) or (q.np_position is None))
-        old_np_ms = q.np_position
+        assert not ((q.current is None) or (q.np_time is None))
+        old_np_ms = q.np_time
         new_np_ms = old_np_ms - int(seconds * 1000)
 
         try:
@@ -463,8 +463,8 @@ async def seek_(
 ):
     async with access_queue(ctx, lvc) as q:
         try:
-            assert q.np_position is not None
-            old_np_ms = q.np_position
+            assert q.np_time is not None
+            old_np_ms = q.np_time
             await seek(ctx, lvc, timestamp)
         except IllegalArgument as xe:
             await err_say(


### PR DESCRIPTION
`?` `Result` -> `Fallible`
`/` `format_flags(...)` -> `split_flags(...)`
`+` `join_truthy(...)`
`*` `QueueList.np_position` -> `.np_time`
`+` Colorized codeblocks lib: `fmt`
 | `+` `ANSI_BLOCK`, `Style`, `Fore`, `Back`, `cl(...)`
 | `*` colorized errors from `on_parser_errors`
 | `*` colorized `/queue` command
 | `*` colorized `/search`
 | `*` colorized output from `/config restrict~prefix list`
`*` Changed `/queue` 's aesthetics
 | `*` new button designs for all of them
 | `*` `Q_CHUNK` is now `15` -> `10`
 | `!` `QueueList.sane_pos` fixing the queue showing the wrong remaining position in footer
 | `/` `QueueList.total_durr`
`*` `generate_queue_embeds(...)` now returns an `itertools.chain`