### PR TITLE
Include `/stop` to affect paused now-playing timestamps (2)

### DIFF
--- a/lyra/src/lib/playback.py
+++ b/lyra/src/lib/playback.py
@@ -37,8 +37,11 @@ from .lava.events import TrackStoppedEvent
 
 async def stop(g_: IntCastable | MaybeGuildIDAware, lvc: lv.Lavalink, /) -> None:
     async with access_queue(g_, lvc) as q:
-        if np_pos := q.np_time:
-            q.update_paused_np_position(np_pos)
+        try:
+            if np_pos := q.np_time:
+                q.update_paused_np_position(np_pos)
+        except QueueEmpty:
+            pass
         q.is_stopped = True
 
     await lvc.stop(infer_guild(g_))


### PR DESCRIPTION
`!` Ignore `QueueEmpty` when calling `stop(...)` as the queue is still empty