### PR TITLE
Improved VC Checks, automatic pauses & cleanups

### DIFF
--- a/lyra/src/lib/__init__.py
+++ b/lyra/src/lib/__init__.py
@@ -1,9 +1,10 @@
 # pyright: reportUnusedImport=false
 from .extras import inj_glob, lgfmt
-from .utils import LyraConfig, EmojiRefs, base_h, restricts_c
+from .utils import LyraConfig, EmojiCache, base_h, restricts_c
 from .connections import cleanup
 from .lava import (
     EventHandler,
+    NodeRef,
     repeat_emojis,
     access_data,
     get_data,

--- a/lyra/src/lib/consts.py
+++ b/lyra/src/lib/consts.py
@@ -5,7 +5,7 @@ import typing as t
 LOG_PAD: t.Final = 16
 """Left aligned padding for each lib's logger name"""
 TIMEOUT: t.Final = 60
-"""Base timeout time for buttons, drop-downs and command's wait for responses in seconds"""
+"""Base timeout duration for buttons, drop-downs and command's wait for responses in seconds"""
 Q_CHUNK: t.Final = 10
 """Amount of tracks in the queue to be displayed per page in the `/queue` command"""
 RETRIES: t.Final = 3
@@ -14,6 +14,11 @@ STOP_REFRESH: t.Final = 0.15
 """How many seconds to wait before checking the next time whether the track is confirmed to be stopped"""
 ADD_TRACKS_WRAP_LIM: t.Final = 3
 """How many tracks to be displayed in `/play`'s output before the text got summarized to "Added <i> tracks...\""""
+INACTIVITY_TIMEOUT: t.Final = 600
+"""Timeout duration for the automatic inactivity disconnection in seconds"""
+INACTIVITY_REFRESH: t.Final = 10
+"""Amount of timeout refreshes to periodically check whether the inactivity condition is still met"""
+
 
 genius_icon: t.Final = (
     'https://images.genius.com/2f65c7544798653b46b7a1f132ce8768.512x512x1.png'

--- a/lyra/src/lib/lava/__init__.py
+++ b/lyra/src/lib/lava/__init__.py
@@ -1,6 +1,7 @@
 # pyright: reportUnusedImport=false
 from .utils import (
     NodeData,
+    NodeRef,
     QueueList,
     Bands,
     RepeatMode,

--- a/lyra/src/lib/lava/impl.py
+++ b/lyra/src/lib/lava/impl.py
@@ -8,7 +8,7 @@ import lavasnek_rs as lv
 from ..extras import Panic, lgfmt
 from ..dataimpl import LyraDBClientType, LyraDBCollectionType
 from ..errors import QueueEmptyError
-from ..utils import EmojiRefs, get_client
+from ..utils import EmojiCache, get_client
 from ..playback import while_stop, skip
 from .utils import (
     BaseEventHandler,
@@ -54,10 +54,10 @@ class EventHandler(BaseEventHandler):
             client = get_client()
 
             cfg = client.get_type_dependency(LyraDBCollectionType)
-            erf = client.get_type_dependency(EmojiRefs)
+            emj = client.get_type_dependency(EmojiCache)
 
             assert not isinstance(cfg, al.abc.Undefined) and not isinstance(
-                erf, al.abc.Undefined
+                emj, al.abc.Undefined
             )
 
             g_cfg = cfg.find_one({'id': str(event.guild_id)})
@@ -74,16 +74,16 @@ class EventHandler(BaseEventHandler):
             controls = (
                 client.rest.build_action_row()
                 .add_button(hk.ButtonStyle.SECONDARY, 'lyra_shuffle')
-                .set_emoji(erf['shuffle_b'])
+                .set_emoji(emj['shuffle_b'])
                 .add_to_container()
                 .add_button(hk.ButtonStyle.SECONDARY, 'lyra_previous')
-                .set_emoji(erf['previous_b'])
+                .set_emoji(emj['previous_b'])
                 .add_to_container()
                 .add_button(hk.ButtonStyle.PRIMARY, 'lyra_playpause')
-                .set_emoji(erf['resume_b'])
+                .set_emoji(emj['resume_b'])
                 .add_to_container()
                 .add_button(hk.ButtonStyle.SECONDARY, 'lyra_skip')
-                .set_emoji(erf['skip_b'])
+                .set_emoji(emj['skip_b'])
                 .add_to_container()
                 .add_button(hk.ButtonStyle.SUCCESS, 'lyra_repeat')
                 .set_emoji(get_repeat_emoji(q))
@@ -102,7 +102,7 @@ class EventHandler(BaseEventHandler):
         t = (await lvc.decode_track(event.track)).title
         if not await lvc.get_guild_node(event.guild_id):
             return
-        async with access_data(event.guild_id, lvc) as d:
+        async with access_data(event.guild_id, lvc, strict=False) as d:
             q = d.queue
             l = len(q)
 

--- a/lyra/src/lib/utils/__init__.py
+++ b/lyra/src/lib/utils/__init__.py
@@ -32,5 +32,5 @@ from .funcs import (
     with_message_command_group_template,
     color_hash_obj,
 )
-from .vars import RESTRICTOR, EmojiRefs, DJ_PERMS, dj_perms_fmt, guild_c, base_h
+from .vars import RESTRICTOR, EmojiCache, DJ_PERMS, dj_perms_fmt, guild_c, base_h
 from .fmt import Style, Fore, ANSI_BLOCK, cl

--- a/lyra/src/lib/utils/funcs.py
+++ b/lyra/src/lib/utils/funcs.py
@@ -26,7 +26,7 @@ from ..dataimpl import LyraDBCollectionType
 from .vars import RESTRICTOR, base_h
 from .types import (
     ChannelAware,
-    RESTAware,
+    PurelyRESTAware,
     RESTAwareAware,
     ClientAware,
     ClientAwareGuildContextish,
@@ -591,10 +591,10 @@ async def pre_execution(
 
     assert ctx.guild_id and ctx.cache
 
-    bot_u = ctx.cache.get_me()
-    assert bot_u
+    g = ctx.get_guild()
+    assert g
 
-    bot_m = ctx.cache.get_member(ctx.guild_id, bot_u)
+    bot_m = g.get_my_member()
     assert bot_m
 
     bot_perms = await tj.permissions.fetch_permissions(
@@ -635,8 +635,8 @@ def get_client(_c_inf: AnyOr[ClientAware] = None, /) -> tj.abc.Client:
     return _c
 
 
-def get_rest(g_r_inf: RESTAware | RESTAwareAware, /):
-    if isinstance(g_r_inf, RESTAware):
+def get_rest(g_r_inf: PurelyRESTAware | RESTAwareAware, /):
+    if isinstance(g_r_inf, PurelyRESTAware):
         return g_r_inf.rest
     return g_r_inf.app.rest
 

--- a/lyra/src/lib/utils/types.py
+++ b/lyra/src/lib/utils/types.py
@@ -72,7 +72,7 @@ class Contextish(ChannelAware, t.Protocol):
 
 
 @t.runtime_checkable
-class RESTAware(t.Protocol):
+class PurelyRESTAware(t.Protocol):
     @property
     def rest(self) -> hk.api.RESTClient:
         ...

--- a/lyra/src/lib/utils/vars.py
+++ b/lyra/src/lib/utils/vars.py
@@ -6,7 +6,7 @@ import tanjun as tj
 from ..extras import format_flags
 
 
-EmojiRefs = t.NewType('EmojiRefs', dict[str, hk.KnownCustomEmoji])
+EmojiCache = t.NewType('EmojiCache', dict[str, hk.KnownCustomEmoji])
 base_h = tj.AnyHooks()
 guild_c = tj.checks.GuildCheck(
     error_message="🙅 Commands can only be used in guild channels"

--- a/lyra/src/modules/info.py
+++ b/lyra/src/modules/info.py
@@ -12,7 +12,7 @@ from ..lib.errors import QueryEmptyError, LyricsNotFoundError
 from ..lib.utils import (
     Fore,
     AnyContextType,
-    EmojiRefs,
+    EmojiCache,
     ANSI_BLOCK,
     cl,
     limit_img_size_by_guild,
@@ -156,8 +156,8 @@ async def search_c(
 
 
 async def _search(ctx: tj.abc.Context, query: str, lvc: lv.Lavalink) -> Fallible[None]:
-    erf = ctx.client.get_type_dependency(EmojiRefs)
-    assert ctx.guild_id and not isinstance(erf, al.abc.Undefined)
+    emj = ctx.client.get_type_dependency(EmojiCache)
+    assert ctx.guild_id and not isinstance(emj, al.abc.Undefined)
 
     query = query.strip("<>|")
 
@@ -225,7 +225,7 @@ async def _search(ctx: tj.abc.Context, query: str, lvc: lv.Lavalink) -> Fallible
         .set_label("Get Link")
         .add_to_container()
         .add_button(hk.ButtonStyle.DANGER, 'cancel')
-        .set_emoji(erf['exit_b'])
+        .set_emoji(emj['exit_b'])
         .add_to_container()
     )
     components.append(ops_row)
@@ -365,7 +365,7 @@ async def queue_(
     ctx: tj.abc.Context,
     bot: al.Injected[hk.GatewayBot],
     lvc: al.Injected[lv.Lavalink],
-    erf: al.Injected[EmojiRefs],
+    emj: al.Injected[EmojiCache],
 ):
     q = await get_queue(ctx, lvc)
     pages = (*(await generate_queue_embeds(ctx, lvc)),)
@@ -375,29 +375,29 @@ async def queue_(
         row = ctx.rest.build_action_row()
 
         row.add_button(hk.ButtonStyle.SECONDARY, 'first').set_emoji(
-            erf['first_b']
+            emj['first_b']
         ).add_to_container()
 
         row.add_button(hk.ButtonStyle.SECONDARY, 'prev').set_emoji(
-            erf['prev_b']
+            emj['prev_b']
         ).add_to_container()
 
         if cancel_b:
             _3rd_b = row.add_button(hk.ButtonStyle.DANGER, 'exit').set_emoji(
-                erf['exit_b']
+                emj['exit_b']
             )
         else:
             _3rd_b = row.add_button(hk.ButtonStyle.PRIMARY, 'back').set_emoji(
-                erf['back_b']
+                emj['back_b']
             )
         _3rd_b.add_to_container()
 
         row.add_button(hk.ButtonStyle.SECONDARY, 'next').set_emoji(
-            erf['next_b']
+            emj['next_b']
         ).add_to_container()
 
         row.add_button(hk.ButtonStyle.SECONDARY, 'last').set_emoji(
-            erf['last_b']
+            emj['last_b']
         ).add_to_container()
 
         return row
@@ -407,10 +407,10 @@ async def queue_(
 
     def _update_buttons(b: hk.api.ButtonBuilder[hk.api.ActionRowBuilder]):
         return (
-            (not pages[:i] and b.emoji == erf['prev_b'])
-            or (not pages[i + 1 :] and b.emoji == erf['next_b'])
-            or (i == 0 and b.emoji == erf['first_b'])
-            or (i == pages_n - 1 and b.emoji == erf['last_b'])
+            (not pages[:i] and b.emoji == emj['prev_b'])
+            or (not pages[i + 1 :] and b.emoji == emj['next_b'])
+            or (i == 0 and b.emoji == emj['first_b'])
+            or (i == pages_n - 1 and b.emoji == emj['last_b'])
         )
 
     embed = pages[i].set_author(name=f"Page {i+1}/{pages_n}")
@@ -482,7 +482,7 @@ async def lyrics_(
     ctx: tj.abc.Context,
     bot: al.Injected[hk.GatewayBot],
     lvc: al.Injected[lv.Lavalink],
-    erf: al.Injected[EmojiRefs],
+    emj: al.Injected[EmojiCache],
     song: t.Annotated[
         Option[ja.Greedy[ja.Str]], "What song? (If not given, the current song)"
     ] = None,
@@ -490,7 +490,7 @@ async def lyrics_(
     """Attempts to find the lyrics of the current song"""
 
     assert not isinstance(bot, al.abc.Undefined) and not isinstance(
-        erf, al.abc.Undefined
+        emj, al.abc.Undefined
     )
 
     if song is None:
@@ -511,7 +511,7 @@ async def lyrics_(
 
     ly_sel = sel_row.add_select_menu('ly_sel')
     cancel_b = act_row.add_button(hk.ButtonStyle.DANGER, 'delete').set_emoji(
-        erf['exit_b']
+        emj['exit_b']
     )
 
     try:
@@ -524,12 +524,12 @@ async def lyrics_(
     for source in lyrics:
         (
             ly_sel.add_option(source, source)
-            .set_emoji(erf[source.casefold()])
+            .set_emoji(emj[source.casefold()])
             .set_description(f"The lyrics fetched from {source}")
             .add_to_menu()
         )
 
-    icons: tuple[str] = (*(erf[source.casefold()].url for source in lyrics),)
+    icons: tuple[str] = (*(emj[source.casefold()].url for source in lyrics),)
 
     # (
     #     ly_sel.add_option('Cancel', 'cancel')

--- a/lyra/src/modules/misc.py
+++ b/lyra/src/modules/misc.py
@@ -11,7 +11,7 @@ import alluka as al
 from ..lib.extras import groupby
 from ..lib.utils import (
     LyraConfig,
-    EmojiRefs,
+    EmojiCache,
     color_hash_obj,
     say,
 )
@@ -163,7 +163,7 @@ async def ping_(ctx: tj.abc.Context):
 async def help_(
     ctx: tj.abc.Context,
     command: list[GenericCommandType],
-    erf: al.Injected[EmojiRefs],
+    emj: al.Injected[EmojiCache],
 ):
     # await err_say(ctx, content="⚡ This command is coming soon!")
     cmd = command[-1]
@@ -176,13 +176,13 @@ async def help_(
     if any(
         isinstance(_cmd, tj.SlashCommand | tj.SlashCommandGroup) for _cmd in command
     ):
-        avail_in.append(erf['slash'])
+        avail_in.append(emj['slash'])
     if any(
         isinstance(_cmd, tj.MessageCommand | tj.MessageCommandGroup) for _cmd in command
     ):
-        avail_in.append(erf['prefix'])
+        avail_in.append(emj['prefix'])
     if any(isinstance(_cmd, tj.MenuCommand) for _cmd in command):
-        avail_in.append(erf['menu'])
+        avail_in.append(emj['menu'])
 
     desc = f"{' '.join(map(str, avail_in))}\n```{docs}```\n**Command Category**: `{component.name}`"
 


### PR DESCRIPTION
`?` `EmojiRefs` -> `EmojICache`
`+` System to delete dangling np msgs
 | `+` `NodeRef` injected dep
 | `*` `cleanup(...)` now takes `hk.GatewayBot` obj instead of `hk.ShardAware`
 | `+` func overloads for `cleanup(...)`
 | `+` `also_del_np_msg` kwargs for `cleanup(...)`
`?` Suppressed the majority of unhandled errors
 | `+` `strict` kwargs for `set_data(...)`, `access_data&queue&equalizer(...)`
`?` `RESTAware` -> `PurelyRESTAware`
`?` Optimized some code
`~` abstracted `INACTIVITY_TIMEOUT&REFRESH` to `consts.py`
`*` utilises ctxmngr `access_...(...)` where more applicable
`?` Removed some old code & comments
`+` bot will now send a message when it's been muted/unmuted
 | `!` Fixed bot saying it's been moved when it's been muted/unmuted